### PR TITLE
Add wish list item

### DIFF
--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -40,7 +40,11 @@ a rate with no data.
 
 Sample simulate
 ***************
-Enable the simulate `sample method <https://dismod-at.readthedocs.io/sample_command.html#simulate-index>`_ in the CSV interface. Also add documentation for sample_index to the :ref:`csv_predict@fit-predict-csv` page, and for the simulate and asymptotic sampling methods from the dismod_at documentation to relevant at_cascade pages.
+Enable the simulate `sample method
+<https://dismod-at.readthedocs.io/sample_command.html#simulate-index>`_ in
+the CSV interface. Also add documentation for sample_index to the 
+:ref:`csv_predict@fit_predict.csv` page, and for the simulate and asymptotic 
+sampling methods from the dismod_at documentation to relevant at_cascade pages.
 
 Meta Regression
 ***************

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -8,6 +8,7 @@
    covariance
    Outputting
    std
+   readthedocs
 }
 
 Wish List for at_cascade
@@ -43,8 +44,9 @@ Sample simulate
 Enable the simulate `sample method
 <https://dismod-at.readthedocs.io/sample_command.html#simulate-index>`_ in
 the CSV interface. Also add documentation for sample_index to the 
-:ref:`csv_predict@fit_predict.csv` page, and for the simulate and asymptotic 
-sampling methods from the dismod_at documentation to relevant at_cascade pages.
+:ref:`csv_predict@Output Files@fit_predict.csv` page, and for the simulate and 
+asymptotic sampling methods from the dismod_at documentation to relevant 
+at_cascade pages.
 
 Meta Regression
 ***************

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -38,6 +38,10 @@ a rate with no data.
    This would also require automatically determining which covariate
    multipliers are connected to which problem.
 
+Sample simulate
+***************
+Enable the simulate `sample method <https://dismod-at.readthedocs.io/sample_command.html#simulate-index>`_ in the CSV interface. Also add documentation for sample_index to the :ref:`csv_predict@fit-predict-csv` page, and for the simulate and asymptotic sampling methods from the dismod_at documentation to relevant at_cascade pages.
+
 Meta Regression
 ***************
 The extra measurement noise added for the mismatch between the model and the


### PR DESCRIPTION
Add documentation for sample_index and the simulate option in the predict.csv documentation, sample_index documentation was discovered to be missing from the at_cascade pages.

Still working on more parts of the documentation from the dismod_at pages which would be good to incorporate in the at_cascade pages, but I'll submit new PRs for those.