### PR TITLE
Fix mistype in csv.fit/ode_method for method iota_pos_rho_pos

### DIFF
--- a/at_cascade/csv/fit.py
+++ b/at_cascade/csv/fit.py
@@ -300,7 +300,7 @@ In this case an eigen vector method is used to approximate the ODE solution.
 
 iota_pos_rho_pos
 ................
-If *ode_method* is `iota_zero_rho_pos`` ,
+If *ode_method* is ``iota_pos_rho_pos`` ,
 the smoothing for
 *iota* and *rho*
 must always have lower limit greater than zero.


### PR DESCRIPTION
Noticed this while doing some iterating and figured I'd push a fix.