### PR TITLE
Extend csv.predict so that it can predict using samples of the prioir.

### DIFF
--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -43,6 +43,14 @@ that are not modeled.
 csv.fit
 *******
 
+See Priors for Each Fit
+=======================
+Having a node's prior mean and std (or samples) automatically output on the
+prediction grid in some accessible format would be beneficial for assessing fits
+to data for that node. When viewing a node's fit with its fit_predict.csv
+information being able to also view the node's prior and see how it compares to
+the fit would be very good.
+
 Measurement Value Covariate
 ===========================
 Currently :ref:`csv.fit-name` automatically creates an
@@ -61,10 +69,6 @@ Prediction Grid
 ===============
 It would be good to specify a prediction grid that may be different for
 the covariate age-time grid.
-
-See Priors for Each Fit
-=======================
-Outputting prior std or samples so we have uncertainty of the priors.
 
 Retry Fit
 =========


### PR DESCRIPTION
# Type of changes
- Wish list item text
# Changes
## `xrst/wish_list.xrst`
- Moved the wish list item _See Priors for Each Fit_ to the top of the _csv.fit_ section.
- Added some wording to the item about the format in which priors could be most easily viewed in relation to a node's fit, specifically that having a node's prior mean and std accessible in a similar way to the node's fit mean and std, on the prediction grid, would make viewing the node's fit in relation to the prior most straightforward.
# Test
- Ran the xrst build with `bin/run_xrst.sh` using the updated file; test passed with status `run_xrst.sh: OK`.