### PR TITLE
Add wish list item for omitting meas_value covariate effects from predictions

### DIFF
--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -14,6 +14,12 @@
 Wish List for at_cascade
 ########################
 
+Omit Measurement Value Covariates During Prediction
+***************************************************
+Currently there's a bug which causes meas_value covariate effects to be
+included when producing predictions. This is not intended behavior and can
+cause unrealistic predictions.
+
 avgint Table
 ************
 Change :ref:`cascade_root_node-name` so that upon return
@@ -50,12 +56,6 @@ absolute covariate called ``one`` .
 If we also automatically created a covariate
 called ``meas_value`` , we could use it with a meas_value
 covariate multiplier to expand or contract measurements values.
-
-Omit Measurement Value Covariates During Prediction
-===================================================
-Currently there's a bug which causes meas_value covariate effects to be
-included when producing predictions. This is not intended behavior and can
-cause unrealistic predictions.
 
 Continue Cascade
 ================

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -51,6 +51,12 @@ If we also automatically created a covariate
 called ``meas_value`` , we could use it with a meas_value
 covariate multiplier to expand or contract measurements values.
 
+Omit Measurement Value Covariates During Prediction
+===================================================
+Currently there's a bug which causes meas_value covariate effects to be
+included when producing predictions. This is not intended behavior and can
+cause unrealistic predictions.
+
 Continue Cascade
 ================
 There should be a separate csv routine that continues a cascade from a


### PR DESCRIPTION
Already in contact about this but aligning here as well. Add wish list item about resolving the issue with meas_value covariates being included in predictions and in some cases causing unrealistic predictions to be produced.

Wish list builds OK with the new section:
```bash
$ bin/run_xrst.sh
xrst --local_toc --target html --html_theme sphinx_rtd_theme --index_page_name at_cascade 
Using following input_files: git ls-files
sphinx-build -b html -j 1 build/rst build/html
rm -r build/html/_sources
cp -r build/rst/_sources build/html/_sources
xrst: OK
run_xrst.sh: OK
```

I wasn't sure whether this fit better on the at_cascade wish list or the dismod_at wish list; if it fits better there I can switch it.