### PR TITLE
Support prediction from priors

### DIFF
--- a/at_cascade.xrst
+++ b/at_cascade.xrst
@@ -13,7 +13,7 @@ Cascading Dismod_at Analysis From Parent To Child Regions
 
 Version
 *******
-at_cascade-2024.7.31
+at_cascade-2024.8.18
 
 Git Repository
 **************

--- a/at_cascade.xrst
+++ b/at_cascade.xrst
@@ -13,7 +13,7 @@ Cascading Dismod_at Analysis From Parent To Child Regions
 
 Version
 *******
-at_cascade-2024.8.18
+at_cascade-2024.8.19
 
 Git Repository
 **************

--- a/at_cascade/__init__.py
+++ b/at_cascade/__init__.py
@@ -15,7 +15,7 @@ at_cascade.version
 ******************
 The version number for this copy of at_cascade.
 {xrst_code py}'''
-version = '2024.8.18'
+version = '2024.8.19'
 '''{xrst_code}
 
 at_cascade.constant_table_list

--- a/at_cascade/__init__.py
+++ b/at_cascade/__init__.py
@@ -15,7 +15,7 @@ at_cascade.version
 ******************
 The version number for this copy of at_cascade.
 {xrst_code py}'''
-version = '2024.7.31'
+version = '2024.8.18'
 '''{xrst_code}
 
 at_cascade.constant_table_list

--- a/at_cascade/check_log.py
+++ b/at_cascade/check_log.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: University of Washington <https://www.washington.edu>
-# SPDX-FileContributor: 2021-23 Bradley M. Bell
+# SPDX-FileContributor: 2021-24 Bradley M. Bell
 # ----------------------------------------------------------------------------
 '''
 {xrst_begin check_log}
@@ -21,7 +21,7 @@ Read all the logs for a cascade and return any warning or error messages.
 
 message_type
 ************
-is  equal to ``error`` or ``warning``.
+is  equal to ``error``, ``warning`` or ``at_cascade`` .
 The corresponding messages are returned.
 
 all_node_database
@@ -98,7 +98,7 @@ def check_log(
    assert max_job_depth == None or type(max_job_depth) == int
    # END DEF
    #
-   assert message_type in [ 'error', 'warning' ]
+   assert message_type in [ 'error', 'warning', 'at_cascade' ]
    #
    # node_table, covariate_table
    connection      = dismod_at.create_connection(

--- a/at_cascade/csv/__init__.py
+++ b/at_cascade/csv/__init__.py
@@ -120,6 +120,7 @@ Routines
    at_cascade/csv/pre_parallel.py
    at_cascade/csv/pre_user.py
    at_cascade/csv/predict.py
+   at_cascade/csv/predict_prior.py
    at_cascade/csv/read_table.py
    at_cascade/csv/set_truth.py
    at_cascade/csv/simulate.py
@@ -146,4 +147,5 @@ from .read_table       import read_table
 from .set_truth        import set_truth
 from .simulate         import simulate
 from .write_table      import write_table
+from .predict_prior    import predict_prior
 # END_SORT_THIS_LINE_MINUS_1

--- a/at_cascade/csv/__init__.py
+++ b/at_cascade/csv/__init__.py
@@ -120,7 +120,6 @@ Routines
    at_cascade/csv/pre_parallel.py
    at_cascade/csv/pre_user.py
    at_cascade/csv/predict.py
-   at_cascade/csv/predict_prior.py
    at_cascade/csv/read_table.py
    at_cascade/csv/set_truth.py
    at_cascade/csv/simulate.py

--- a/at_cascade/csv/ancestor_fit.py
+++ b/at_cascade/csv/ancestor_fit.py
@@ -4,6 +4,9 @@
 # ----------------------------------------------------------------------------
 r'''
 {xrst_begin csv.ancestor_fit}
+{xrst_spell
+   msg
+}
 
 Determine Closet Ancestor With Fit and Samples
 ##############################################
@@ -41,10 +44,11 @@ root_split_reference_id
 is the split_reference_id (sex id) for the root node of the cascade.
 The cascade can begin at female, both, or male.
 
-error_message_dict
-******************
-It a dictionary, with keys equal to job names, containing
-the error message for this cascade.
+at_cascade_msg_dict
+*******************
+is a dictionary, with keys equal to job names, containing
+the log messages that have type ``at_cascade`` .
+The messages for each key are in the log table for the corresponding job.
 
 predict_job_dir
 ***************
@@ -75,7 +79,7 @@ def ancestor_fit(
    root_node_id,
    split_reference_table,
    root_split_reference_id,
-   error_message_dict,
+   at_cascade_msg_dict,
 ) :
    assert type(fit_dir) == str
    assert type(job_table) == list
@@ -84,7 +88,7 @@ def ancestor_fit(
    assert type( root_node_id ) == int
    assert type(split_reference_table) == list
    assert type( root_split_reference_id) == int
-   assert type( error_message_dict ) == dict
+   assert type( at_cascade_msg_dict ) == dict
    # END_DEF
    #
    # node_split_set
@@ -111,7 +115,7 @@ def ancestor_fit(
    predict_node_database = f'{fit_dir}/{predict_job_dir}/dismod.db'
    have_fit = False
    if os.path.exists( predict_node_database ) :
-      messages  = error_message_dict[job_name]
+      messages  = at_cascade_msg_dict[job_name]
       have_fit  = 'sample: OK' in messages
    if have_fit :
       ancestor_job_dir = predict_job_dir
@@ -148,7 +152,7 @@ def ancestor_fit(
       # have_fit
       ancestor_job_database = f'{fit_dir}/{ancestor_job_dir}/dismod.db'
       if os.path.exists( ancestor_job_database ) :
-         messages  = error_message_dict[job_name]
+         messages  = at_cascade_msg_dict[job_name]
          have_fit  = 'sample: OK' in messages
    #
    # BEGIN_RETURN

--- a/at_cascade/csv/ancestor_fit.py
+++ b/at_cascade/csv/ancestor_fit.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # SPDX-FileCopyrightText: University of Washington <https://www.washington.edu>
-# SPDX-FileContributor: 2021-23 Bradley M. Bell
+# SPDX-FileContributor: 2021-24 Bradley M. Bell
 # ----------------------------------------------------------------------------
 r'''
 {xrst_begin csv.ancestor_fit}
@@ -109,12 +109,10 @@ def ancestor_fit(
    #
    # have_fit
    predict_node_database = f'{fit_dir}/{predict_job_dir}/dismod.db'
-   if not os.path.exists( predict_node_database ) :
-      have_fit = False
-   elif job_name not in error_message_dict :
-      have_fit = True
-   else :
-      have_fit  = len( error_message_dict[job_name] ) < 2
+   have_fit = False
+   if os.path.exists( predict_node_database ) :
+      messages  = error_message_dict[job_name]
+      have_fit  = 'sample: OK' in messages
    if have_fit :
       ancestor_job_dir = predict_job_dir
       return predict_job_dir, ancestor_job_dir
@@ -149,12 +147,9 @@ def ancestor_fit(
       #
       # have_fit
       ancestor_job_database = f'{fit_dir}/{ancestor_job_dir}/dismod.db'
-      if not os.path.exists( ancestor_job_database ) :
-         have_fit = False
-      elif job_name not in error_message_dict :
-         have_fit = True
-      else :
-         have_fit  = len( error_message_dict[job_name] ) < 2
+      if os.path.exists( ancestor_job_database ) :
+         messages  = error_message_dict[job_name]
+         have_fit  = 'sample: OK' in messages
    #
    # BEGIN_RETURN
    assert type(predict_job_dir) == str

--- a/at_cascade/csv/ancestor_fit.py
+++ b/at_cascade/csv/ancestor_fit.py
@@ -4,9 +4,6 @@
 # ----------------------------------------------------------------------------
 r'''
 {xrst_begin csv.ancestor_fit}
-{xrst_spell
-   msg
-}
 
 Determine Closet Ancestor With Fit and Samples
 ##############################################
@@ -44,7 +41,7 @@ root_split_reference_id
 is the split_reference_id (sex id) for the root node of the cascade.
 The cascade can begin at female, both, or male.
 
-at_cascade_msg_dict
+at_cascade_log_dict
 *******************
 is a dictionary, with keys equal to job names, containing
 the log messages that have type ``at_cascade`` .
@@ -79,7 +76,7 @@ def ancestor_fit(
    root_node_id,
    split_reference_table,
    root_split_reference_id,
-   at_cascade_msg_dict,
+   at_cascade_log_dict,
 ) :
    assert type(fit_dir) == str
    assert type(job_table) == list
@@ -88,7 +85,7 @@ def ancestor_fit(
    assert type( root_node_id ) == int
    assert type(split_reference_table) == list
    assert type( root_split_reference_id) == int
-   assert type( at_cascade_msg_dict ) == dict
+   assert type( at_cascade_log_dict ) == dict
    # END_DEF
    #
    # node_split_set
@@ -111,19 +108,19 @@ def ancestor_fit(
       fit_split_reference_id  = predict_split_reference_id     ,
    )
    #
-   # have_fit
+   # sample_ok
    predict_node_database = f'{fit_dir}/{predict_job_dir}/dismod.db'
-   have_fit = False
+   sample_ok = False
    if os.path.exists( predict_node_database ) :
-      messages  = at_cascade_msg_dict[job_name]
-      have_fit  = 'sample: OK' in messages
-   if have_fit :
+      messages  = at_cascade_log_dict[job_name]
+      sample_ok  = 'sample: OK' in messages
+   if sample_ok :
       ancestor_job_dir = predict_job_dir
       return predict_job_dir, ancestor_job_dir
    #
    # job_id, ancestor_job_dir
    job_id            = predict_job_id
-   while not have_fit :
+   while not sample_ok :
       #
       # job_id
       job_id = job_table[job_id]['parent_job_id']
@@ -149,11 +146,11 @@ def ancestor_fit(
          fit_split_reference_id  = ancestor_split_reference_id     ,
       )
       #
-      # have_fit
+      # sample_ok
       ancestor_job_database = f'{fit_dir}/{ancestor_job_dir}/dismod.db'
       if os.path.exists( ancestor_job_database ) :
-         messages  = at_cascade_msg_dict[job_name]
-         have_fit  = 'sample: OK' in messages
+         messages   = at_cascade_log_dict[job_name]
+         sample_ok  = 'sample: OK' in messages
    #
    # BEGIN_RETURN
    assert type(predict_job_dir) == str

--- a/at_cascade/csv/pre_one_process.py
+++ b/at_cascade/csv/pre_one_process.py
@@ -10,7 +10,6 @@ r'''
 {xrst_spell
    numpy
    dtype
-   msg
 }
 
 Predict Using One Process
@@ -62,17 +61,17 @@ root_split_reference_id
 ***********************
 is the split_reference table id for the root job of the cascade
 
-at_cascade_msg_dict
+at_cascade_log_dict
 *******************
 For each :ref:`create_job_table@job_table@job_name` in the job table
-that is a key in *at_cascade_msg_dict*.  The corresponding value
+that is a key in *at_cascade_log_dict*.  The corresponding value
 
-| *at_cascade_msg_dict* [ *job_name* ]
+| *at_cascade_log_dict* [ *job_name* ]
 
 
 is a non-empty ``list`` of ``str`` containing ``at_cascade`` messages
 in the log table for that job.
-If a *job_name* is not a *key* is in *at_cascade_msg_dict*,
+If a *job_name* is not a *key* is in *at_cascade_log_dict*,
 there were no at_cascade messages for that job.
 
 job_status_name
@@ -169,7 +168,7 @@ def pre_one_process(
    node_table,
    root_node_id,
    root_split_reference_id,
-   at_cascade_msg_dict,
+   at_cascade_log_dict,
    job_status_name,
    shared_job_status_name,
    shared_lock,
@@ -185,7 +184,7 @@ def pre_one_process(
    assert type(node_table[0])              == dict
    assert type(root_node_id)               == int
    assert type(root_split_reference_id)    == int
-   assert type(at_cascade_msg_dict)        == dict
+   assert type(at_cascade_log_dict)        == dict
    assert type(job_status_name)            == list
    assert type( job_status_name[0] )       == str
    assert type(shared_job_status_name)     == str
@@ -266,7 +265,7 @@ def pre_one_process(
          root_node_id            = root_node_id ,
          split_reference_table   = split_reference_table ,
          root_split_reference_id = root_split_reference_id ,
-         at_cascade_msg_dict     = at_cascade_msg_dict ,
+         at_cascade_log_dict     = at_cascade_log_dict ,
       )
       #
       if ancestor_job_dir == None :

--- a/at_cascade/csv/pre_one_process.py
+++ b/at_cascade/csv/pre_one_process.py
@@ -10,6 +10,7 @@ r'''
 {xrst_spell
    numpy
    dtype
+   msg
 }
 
 Predict Using One Process
@@ -61,17 +62,18 @@ root_split_reference_id
 ***********************
 is the split_reference table id for the root job of the cascade
 
-error_message_dict
-******************
+at_cascade_msg_dict
+*******************
 For each :ref:`create_job_table@job_table@job_name` in the job table
-that is a key in *error_message_dict*.  The corresponding value
+that is a key in *at_cascade_msg_dict*.  The corresponding value
 
-| *error_message_dict* [ *job_name* ]
+| *at_cascade_msg_dict* [ *job_name* ]
 
 
-is a non-empty ``list`` of ``str`` containing the error messages for that job.
-If a *job_name* is not a *key* is in *error_message_dict*,
-there were no error messages for that job.
+is a non-empty ``list`` of ``str`` containing ``at_cascade`` messages
+in the log table for that job.
+If a *job_name* is not a *key* is in *at_cascade_msg_dict*,
+there were no at_cascade messages for that job.
 
 job_status_name
 ***************
@@ -167,7 +169,7 @@ def pre_one_process(
    node_table,
    root_node_id,
    root_split_reference_id,
-   error_message_dict,
+   at_cascade_msg_dict,
    job_status_name,
    shared_job_status_name,
    shared_lock,
@@ -183,7 +185,7 @@ def pre_one_process(
    assert type(node_table[0])              == dict
    assert type(root_node_id)               == int
    assert type(root_split_reference_id)    == int
-   assert type(error_message_dict)         == dict
+   assert type(at_cascade_msg_dict)        == dict
    assert type(job_status_name)            == list
    assert type( job_status_name[0] )       == str
    assert type(shared_job_status_name)     == str
@@ -264,7 +266,7 @@ def pre_one_process(
          root_node_id            = root_node_id ,
          split_reference_table   = split_reference_table ,
          root_split_reference_id = root_split_reference_id ,
-         error_message_dict      = error_message_dict ,
+         at_cascade_msg_dict     = at_cascade_msg_dict ,
       )
       #
       if ancestor_job_dir == None :

--- a/at_cascade/csv/pre_parallel.py
+++ b/at_cascade/csv/pre_parallel.py
@@ -180,7 +180,7 @@ def pre_parallel(
    #
    # error_message_dict
    error_message_dict = at_cascade.check_log(
-      message_type       = 'error'              ,
+      message_type       = 'at_cascade'         ,
       all_node_database  = all_node_db          ,
       root_node_database = root_node_database   ,
       fit_goal_set       = fit_goal_set         ,

--- a/at_cascade/csv/pre_parallel.py
+++ b/at_cascade/csv/pre_parallel.py
@@ -178,8 +178,8 @@ def pre_parallel(
       msg += f'The root job name for this cascade is {root_job_name}.'
       assert False, msg
    #
-   # error_message_dict
-   error_message_dict = at_cascade.check_log(
+   # at_cascade_msg_dict
+   at_cascade_msg_dict = at_cascade.check_log(
       message_type       = 'at_cascade'         ,
       all_node_database  = all_node_db          ,
       root_node_database = root_node_database   ,
@@ -259,7 +259,7 @@ def pre_parallel(
             node_table,
             root_node_id,
             root_split_reference_id,
-            error_message_dict,
+            at_cascade_msg_dict,
             job_status_name,
             shared_job_status_name,
             shared_lock,
@@ -280,7 +280,7 @@ def pre_parallel(
       node_table,
       root_node_id,
       root_split_reference_id,
-      error_message_dict,
+      at_cascade_msg_dict,
       job_status_name,
       shared_job_status_name,
       shared_lock,

--- a/at_cascade/csv/pre_parallel.py
+++ b/at_cascade/csv/pre_parallel.py
@@ -178,8 +178,8 @@ def pre_parallel(
       msg += f'The root job name for this cascade is {root_job_name}.'
       assert False, msg
    #
-   # at_cascade_msg_dict
-   at_cascade_msg_dict = at_cascade.check_log(
+   # at_cascade_log_dict
+   at_cascade_log_dict = at_cascade.check_log(
       message_type       = 'at_cascade'         ,
       all_node_database  = all_node_db          ,
       root_node_database = root_node_database   ,
@@ -259,7 +259,7 @@ def pre_parallel(
             node_table,
             root_node_id,
             root_split_reference_id,
-            at_cascade_msg_dict,
+            at_cascade_log_dict,
             job_status_name,
             shared_job_status_name,
             shared_lock,
@@ -280,7 +280,7 @@ def pre_parallel(
       node_table,
       root_node_id,
       root_split_reference_id,
-      at_cascade_msg_dict,
+      at_cascade_log_dict,
       job_status_name,
       shared_job_status_name,
       shared_lock,

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: University of Washington <https://www.washington.edu>
+# SPDX-FileContributor: 2024-06 Nate Temiquel, Garland Culbreth
+# ----------------------------------------------------------------------------
 import os
 import dismod_at
 

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -87,7 +87,4 @@ def predict_prior(fit_dir):
    # prior_pred.db sample
    command = [ 'dismod_at', database, 'sample' , 'asymptotic', 'both', '20' ]
    dismod_at.system_command_prc(command)
-   #
-   # finish with success message
-   print('predict_prior.py: OK')
 #

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -4,17 +4,17 @@
 # ----------------------------------------------------------------------------
 import os
 import dismod_at
-
-
+#
+#
 def predict_prior(fit_dir):
    # job_dir
    job_dir = f'{fit_dir}/n0'
-   
+   #
    # prior_pred.db
    command = [ 'cp', f'{job_dir}/dismod.db', f'{job_dir}/prior_pred.db' ]
    dismod_at.system_command_prc(command)
    # prior_connect
-   prior_connect = dismod_at.create_connection( 
+   prior_connect = dismod_at.create_connection(
       file_name = f'{job_dir}/prior_pred.db' ,
       new       = False ,
       readonly  = False ,
@@ -27,9 +27,9 @@ def predict_prior(fit_dir):
          row['option_value'] = option_value.replace( ' data ', ' ' )
    # prior_pred.db: option_table
    dismod_at.replace_table(
-      prior_connect, 
+      prior_connect,
       tbl_name   = 'option',
-      table_dict = option_table, 
+      table_dict = option_table,
    )
    # data_table
    connection = dismod_at.create_connection(
@@ -72,7 +72,7 @@ def predict_prior(fit_dir):
    )
    # prior_connect
    prior_connect.close()
-   
+   #
    # prior_pred.db: init
    command  = [ 'dismod_at', f'{job_dir}/prior_pred.db', 'init' ]
    sigma    = '.3'
@@ -87,6 +87,7 @@ def predict_prior(fit_dir):
    # prior_pred.db sample
    command = [ 'dismod_at', database, 'sample' , 'asymptotic', 'both', '20' ]
    dismod_at.system_command_prc(command)
-   
+   #
    # finish with success message
    print('predict_prior.py: OK')
+#

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -7,9 +7,22 @@ import dismod_at
 #
 #
 def predict_prior(fit_dir):
-   # job_dir
-   job_dir = f'{fit_dir}/n0'
-   #
+      start_job_name = 'n0.both'
+      max_job_depth  = 0
+      args           = ( fit_dir, f'{fit_dir}/n0/', start_job_name, max_job_depth )
+      predict_prior_calc( *args )
+      #
+      # Run predict starting at
+      # n1.female, n1.male, n2.female, n2.male.
+      for node_name in [ 'n1', 'n2' ] :
+         for sex in [ 'female', 'male' ] :
+            start_job_name = f'{node_name}.{sex}'
+            job_dir = f'{fit_dir}/n0/{sex}/{node_name}/'
+            args           = ( fit_dir, job_dir, start_job_name, max_job_depth )
+            predict_prior_calc(*args)
+
+def predict_prior_calc(fit_dir, job_dir, predict_job_name, max_node_depth = 0):
+   root_node_name = 'n0'
    # prior_pred.db
    command = [ 'cp', f'{job_dir}/dismod.db', f'{job_dir}/prior_pred.db' ]
    dismod_at.system_command_prc(command)
@@ -87,4 +100,211 @@ def predict_prior(fit_dir):
    # prior_pred.db sample
    command = [ 'dismod_at', database, 'sample' , 'asymptotic', 'both', '20' ]
    dismod_at.system_command_prc(command)
-#
+   # ****************************************************************************
+   # Prediction pipeline variables **********************************************
+   # ****************************************************************************
+   from csv import DictWriter as csvDictWriter
+   from at_cascade import table_name2id, fit_or_root_class, get_parent_node
+   from at_cascade import csv
+   # covariate_table
+   file_name       = f'{fit_dir}/covariate.csv'
+   covariate_table = csv.read_table(file_name)
+   # 
+   # all_node_db
+   all_node_db = f'{fit_dir}/all_node.db'
+   #
+   # root_node_database
+   root_node_database = f'{fit_dir}/root_node.db'
+   #
+   # node_table
+   connection      = dismod_at.create_connection(
+      root_node_database, new = False, readonly = True
+   )
+   node_table      = dismod_at.get_table_dict(connection, 'node')
+   connection.close()
+   # 
+   # fit_goal_table
+   file_name      = f'{fit_dir}/fit_goal.csv'
+   fit_goal_table = csv.read_table(file_name)
+   for row in fit_goal_table :
+      node_name = row['node_name']
+      node_id   = table_name2id(node_table, 'node', node_name)
+      row['node_id'] = node_id
+   #
+   # fit_goal_set
+   fit_goal_set   = set()
+   pred_node_name = predict_job_name[:2]
+   start_node_id  = \
+      table_name2id(node_table, 'node', pred_node_name)
+   for row in fit_goal_table :
+      node_id   = row['node_id']
+      node_list = [ node_id ]
+      while node_id != start_node_id and node_id != None :
+         node_id   = node_table[node_id]['parent']
+         if node_id != None :
+            node_list.append( node_id )
+      if node_id == start_node_id :
+         if max_node_depth == None :
+            node_id   = node_list[0]
+         elif len(node_list) <= max_node_depth + 1 :
+            node_id   = node_list[0]
+         else :
+            node_id  = node_list[-max_node_depth - 1]
+         node_name = node_table[node_id]['node_name']
+         fit_goal_set.add( node_name )
+   #
+   # split reference table
+   # node_table
+   connection      = dismod_at.create_connection(
+      all_node_db, new = False, readonly = True
+   )
+   split_ref_table      = dismod_at.get_table_dict(connection, 'split_reference')
+   connection.close()
+   #
+   # split out sex from predict job name
+   sex_name = predict_job_name[3:]
+   # get id from split_ref_table
+   predict_sex_id = table_name2id(split_ref_table, 'split_reference', sex_name)
+   # 
+   # predict_one
+   csv.pre_one_job(
+      predict_job_name = predict_job_name,
+      fit_dir = fit_dir,
+      sim_dir = None,
+      ancestor_node_database = f'{job_dir}/prior_pred.db',
+      predict_node_id = start_node_id,
+      predict_sex_id = predict_sex_id,
+      all_node_database = all_node_db,
+      all_covariate_table = covariate_table,
+      float_precision = 4,
+      db2csv = True,
+      plot = False,
+      zero_meas_value = False,
+   )
+   #
+   # pre_user
+   # ancestor_database
+   ancestor_database = f'{job_dir}/prior_pred.db'
+   #
+   # ancestor_covariate_table, integrand_table
+   ancestor_or_root   = fit_or_root_class(
+      ancestor_database, root_node_database
+   )
+   ancestor_covariate_table = ancestor_or_root.get_table('covariate')
+   integrand_table          = ancestor_or_root.get_table('integrand')
+   ancestor_or_root.close()
+   #
+   # ancestor_node_name
+   ancestor_node_name = get_parent_node(ancestor_database)
+   #
+   # ancestor_sex_name
+   ancestor_sex_covariate_id = None
+   for (covariate_id, row) in enumerate( ancestor_covariate_table ) :
+      if row['covariate_name'] == 'sex' :
+         ancestor_sex_covariate_id = covariate_id
+   row = ancestor_covariate_table[ancestor_sex_covariate_id]
+   ancestor_sex_value = row['reference']
+   ancestor_sex_name = None
+   for sex_name in csv.sex_name2value :
+      if csv.sex_name2value[sex_name] == ancestor_sex_value :
+         ancestor_sex_name = sex_name
+   #
+   # split_reference_table
+   split_reference_table = csv.split_reference_table
+   #
+   # sex_value2name
+   sex_value2name = dict()
+   for row in split_reference_table :
+      name  = row['split_reference_name']
+      value = row['split_reference_value']
+      sex_value2name[value] = name
+   #
+   # prefix
+   prefix_list = [ 'fit', 'sam' ]
+   prefix_predict_table = { 'tru':list(), 'fit':list(), 'sam':list() }
+   for prefix in prefix_list :
+      #
+      # file_name
+      file_name     = f'{job_dir}/{prefix}_predict.csv'
+      if not os.path.isfile(file_name) :
+         msg = f'csv.predict: Cannot find {file_name}'
+         assert False, msg
+      else :
+         # predict_table
+         predict_table = csv.read_table(file_name)
+         #
+         # prefix_predict_table
+         for row_in in predict_table :
+            # row_out
+            row_out = dict()
+            #
+            # avgint_id
+            row_out['avgint_id'] = row_in['avgint_id']
+            #
+            # avg_integrand
+            row_out['avg_integrand'] = row_in['avg_integrand']
+            #
+            # sample_index
+            if prefix == 'sam' :
+               row_out['sample_index'] = row_in['sample_index']
+            #
+            # age
+            assert float(row_in['age_lower'])  == float(row_in['age_upper'])
+            row_out['age']  = row_in['age_lower']
+            #
+            # time
+            assert float(row_in['time_lower']) == float(row_in['time_upper'])
+            row_out['time'] = row_in['time_lower']
+            #
+            # node_name
+            node_id              = int( row_in['node_id'] )
+            row_out['node_name'] = node_table[node_id]['node_name']
+            assert node_id == start_node_id
+            #
+            # fit_node_name
+            row_out['fit_node_name'] = ancestor_node_name
+            #
+            # fit_sex
+            row_out['fit_sex'] = ancestor_sex_name
+            #
+            # integrand_name
+            integrand_id  = int( row_in['integrand_id'] )
+            row_out['integrand_name'] = \
+               integrand_table[integrand_id]['integrand_name']
+            #
+            # covariate_name
+            # for each covariate in predict_table
+            for (i_cov, cov_row) in enumerate( ancestor_covariate_table ) :
+               covariate_name = cov_row['covariate_name']
+               covariate_key  = f'x_{i_cov}'
+               cov_value      = float( row_in[covariate_key] )
+               if covariate_name == 'sex' :
+                  row_tmp   = split_reference_table[predict_sex_id]
+                  assert cov_value == row_tmp['split_reference_value']
+                  cov_value = sex_value2name[cov_value]
+               row_out[covariate_name] = cov_value
+            #
+            # prefix_predict_table
+            prefix_predict_table[prefix].append( row_out )
+            #
+   #
+   # prefix_predict.csv
+   for prefix in prefix_list :
+      file_name    = f'{fit_dir}/{prefix}_predict.csv'
+      if (os.path.exists(file_name)):
+         new_file = False
+      else:
+         new_file = True
+      file_out     = open(file_name, 'a')
+      writer       = None
+      for row in prefix_predict_table[prefix]:
+         if writer == None :
+            writer = csvDictWriter(file_out, fieldnames = row.keys() )
+            if new_file:
+               writer.writeheader()
+         writer.writerow(row)
+      file_out.close()
+         
+
+
+

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -86,19 +86,3 @@ def predict_prior(fit_dir):
    
    # finish with success message
    print('predict_prior.py: OK')
-
-
-"""
-Note: For initial test runs I've been calling this using the below with:
-
-command = [ 'python3', 'at_cascade/csv/predict_prior.py' ] 
-if True :
-   dismod_at.system_command_prc(command)
-print('prior_pred.py: OK')
-
-since I can't get it to do at_cascade.csv.predict_prior() without a module
-not found error yet. Once I have that fixed I'll remove this section
-"""
-if __name__ == '__main__':
-   current_directory = os.getcwd()
-   predict_prior(fit_dir=os.path.join(current_directory, 'build/example/csv'))

--- a/at_cascade/csv/predict_prior.py
+++ b/at_cascade/csv/predict_prior.py
@@ -1,0 +1,104 @@
+import os
+import dismod_at
+
+
+def predict_prior(fit_dir):
+   # job_dir
+   job_dir = f'{fit_dir}/n0'
+   
+   # prior_pred.db
+   command = [ 'cp', f'{job_dir}/dismod.db', f'{job_dir}/prior_pred.db' ]
+   dismod_at.system_command_prc(command)
+   # prior_connect
+   prior_connect = dismod_at.create_connection( 
+      file_name = f'{job_dir}/prior_pred.db' ,
+      new       = False ,
+      readonly  = False ,
+   )
+   # option_table
+   option_table = dismod_at.get_table_dict(prior_connect, tbl_name = 'option')
+   for row in option_table :
+      if row['option_name'] == 'other_input_table' :
+         option_value = ' ' + row['option_value'] + ' '
+         row['option_value'] = option_value.replace( ' data ', ' ' )
+   # prior_pred.db: option_table
+   dismod_at.replace_table(
+      prior_connect, 
+      tbl_name   = 'option',
+      table_dict = option_table, 
+   )
+   # data_table
+   connection = dismod_at.create_connection(
+      file_name = f'{fit_dir}/root_node.db' ,
+      new       = False ,
+      readonly  = True  ,
+   )
+   data_table = dismod_at.get_table_dict(connection, tbl_name = 'data')
+   connection.close()
+   # col_name, col_type
+   row      = data_table[0]
+   col_name = list()
+   col_type = list()
+   for key in row :
+      python_type = type( row[key] )
+      sql_type = None
+      if python_type == str :
+         sql_type = 'text'
+      elif python_type == int :
+         sql_type = 'integer'
+      elif python_type == float :
+         sql_type = 'real'
+      elif row[key] == None :
+         if key in [ 'weight_id', 'sample_size' ] :
+            sql_type = 'integer'
+         elif key in [ 'eta', 'nu' ] :
+            sql_type = 'real'
+      if sql_type == None :
+         assert False, f'key = {key}, python_type = {python_type}'
+      #
+      col_name.append(key)
+      col_type.append(sql_type)
+   # prior_pred.db: data_table
+   dismod_at.create_table(
+      connection = prior_connect ,
+      tbl_name   = 'data'        ,
+      col_name   = col_name      ,
+      col_type   = col_type      ,
+      row_list   = list()        ,
+   )
+   # prior_connect
+   prior_connect.close()
+   
+   # prior_pred.db: init
+   command  = [ 'dismod_at', f'{job_dir}/prior_pred.db', 'init' ]
+   sigma    = '.3'
+   database = f'{job_dir}/prior_pred.db'
+   dismod_at.system_command_prc(command)
+   for tbl_name in [ 'scale_var', 'start_var' ] :
+      command = [ 'dismodat.py', database, 'perturb', tbl_name, sigma ]
+      dismod_at.system_command_prc(command)
+   # prior_pred.db: fit
+   command = [ 'dismod_at', database, 'fit' , 'both' ]
+   dismod_at.system_command_prc(command)
+   # prior_pred.db sample
+   command = [ 'dismod_at', database, 'sample' , 'asymptotic', 'both', '20' ]
+   dismod_at.system_command_prc(command)
+   
+   # finish with success message
+   print('predict_prior.py: OK')
+
+
+"""
+Note: For initial test runs I've been calling this using the below with:
+
+command = [ 'python3', 'at_cascade/csv/predict_prior.py' ] 
+if True :
+   dismod_at.system_command_prc(command)
+print('prior_pred.py: OK')
+
+since I can't get it to do at_cascade.csv.predict_prior() without a module
+not found error yet. Once I have that fixed I'll remove this section
+"""
+if __name__ == '__main__':
+   current_directory = os.getcwd()
+   predict_prior(fit_dir=os.path.join(current_directory, 'build/example/csv'))

--- a/at_cascade/fit_one_job.py
+++ b/at_cascade/fit_one_job.py
@@ -92,9 +92,24 @@ distribution for the model variables for the fit_node.
 
 log
 ===
-If *fit_type* is 'both', the previous contents of the log are removed.
-Upon return,
-a summary of the operations preformed on dismod.db is added to the log table.
+Upon return, a summary of the operations preformed by dismod.
+In addition, the following entries are added to the log table:
+
+.. csv-table::
+   :header-rows:1
+
+   message_type, message,        meaning
+   at_cascade,   no data: abort, abort this fit because there is no data
+   at_cascade,   fit: OK,        the maximum likelihood problem was solved
+   at_cascade,   sample: OK,     the posterior samples were computed
+   at_cascade,   children: OK,   the child databases were created (with priors)
+
+Exception
+*********
+If there is no data from this fit, this routine will raise an exception
+with a message that starts with: ``no data: abort`` ; i.e., the same
+as the message it puts in the log.
+
 
 {xrst_end fit_one_job}
 '''
@@ -300,6 +315,20 @@ def fit_one_job(
    command = [ 'dismod_at', fit_node_database, 'init' ]
    system_command(command, file_stdout)
    #
+   # fit_node_datase.log_table
+   # if fit has no data, abort with 'fit: error: no data abort' in log_table
+   connection = dismod_at.create_connection(
+      fit_node_database, new = False, readonly = False
+   )
+   data_subset_table = dismod_at.get_table_dict(connection, 'data_subset')
+   if len( data_subset_table )  == 0 :
+      msg      = 'no data: abort'
+      at_cascade.add_log_entry(connection, msg)
+      job_name = job_table[run_job_id]['job_name']
+      msg      = f'no data: abort {job_name}'
+      raise Exception(msg)
+   connection.close()
+   #
    # max_fit
    if 'max_fit' in option_all_dict :
       max_fit = option_all_dict['max_fit']
@@ -336,6 +365,14 @@ def fit_one_job(
    command = [ 'dismod_at', fit_node_database, 'fit', fit_type ]
    system_command(command, file_stdout)
    #
+   # fit_node_database.log_table
+   connection = dismod_at.create_connection(
+      fit_node_database, new = False, readonly = False
+   )
+   msg      = 'fit: OK'
+   at_cascade.add_log_entry(connection, msg)
+   connection.close()
+   #
    # number_simulate
    if 'number_sample' not in option_all_dict :
       number_simulate = '20'
@@ -366,6 +403,14 @@ def fit_one_job(
    ]
    system_command(command, file_stdout)
    #
+   # fit_node_database.log_table
+   connection = dismod_at.create_connection(
+      fit_node_database, new = False, readonly = False
+   )
+   msg      = 'sample: OK'
+   at_cascade.add_log_entry(connection, msg)
+   connection.close()
+   #
    # avgint_parent_grid
    at_cascade.avgint_parent_grid(
       all_node_database = all_node_database ,
@@ -378,9 +423,6 @@ def fit_one_job(
    connection = dismod_at.create_connection(
       fit_node_database, new = False, readonly = False
    )
-   #
-   # log avgint_parent_grid
-   at_cascade.add_log_entry(connection, 'avgint_parent_grid')
    #
    # c_shift_predict_fit_var
    command = [ 'dismod_at', fit_node_database, 'predict', 'fit_var' ]
@@ -454,6 +496,15 @@ def fit_one_job(
       fit_node_database, new = False, readonly = False
    )
    at_cascade.empty_avgint_table(connection)
+   connection.close()
+   #
+   #
+   # fit_node_database.log_table
+   connection = dismod_at.create_connection(
+      fit_node_database, new = False, readonly = False
+   )
+   msg      = 'children: OK'
+   at_cascade.add_log_entry(connection, msg)
    connection.close()
    #
    # trace_line_number( inspect.currentframe().f_lineno )

--- a/at_cascade/fit_one_process.py
+++ b/at_cascade/fit_one_process.py
@@ -245,10 +245,11 @@ def try_one_job(
       trace_file_name = f'{result_database_dir}/trace.out'
       trace_file_obj  = open(trace_file_name, 'w')
    #
-   # job_done, fit_type_index, fit_type
+   # job_done, fit_type_index, fit_type, have_data
    job_done       = False
+   have_data      = True
    fit_type_index = 0
-   while (not job_done) and ( fit_type_index < len(fit_type_list) ) :
+   while have_data and (not job_done) and (fit_type_index< len(fit_type_list)) :
       fit_type        = fit_type_list[fit_type_index]
       fit_type_index += 1
       #
@@ -290,8 +291,10 @@ def try_one_job(
             job_done = True
          except Exception as e:
             job_done = False
-            #
-            print( f'\nfit {fit_type:<5} {job_name} message:\n' + str(e) )
+            msg      = str(e)
+            if msg.startswith( 'no data: abort' ) :
+               have_data = False
+            print( f'\nfit {fit_type:<5} {job_name} message:\n' + msg )
    #
    # trace_file_obj
    if trace_file_obj != None :

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -14,77 +14,25 @@ current_directory = os.getcwd()
 if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
    sys.path.insert(0, current_directory)
 import at_cascade
-"""
-{xrst_begin csv.break_fit_pred}
-{xrst_spell
-   const
-   dage
-   delim
-   dtime
-   eps
-   haqi
-   meas
-   sincidence
-   std
-   uniform uniform
-}
-
-Breakup Fitting and Prediction and Run in Parallel
-##################################################
-
-csv_file
-********
-This dictionary is used to hold the data corresponding to the
-csv files for this example:
-{xrst_code py}"""
+#
 csv_file = dict()
-"""{xrst_code}
-
-node.csv
-********
-For this example the root node, n0, has two children, n1 and n2.
-{xrst_code py}"""
 csv_file['node.csv'] = \
 '''node_name,parent_name
 n0,
 n1,n0
 n2,n0
 '''
-"""{xrst_code}
-
-option_fit.csv
-**************
-This example uses the default value for all the options in option_fit.csv
-except for:
-
-#. random_seed is chosen using the python time package
-#. refit_split is set to false
-#. max_number_cpu should be either 1 or None
-
-{xrst_code py}"""
+#
 max_number_cpu = None
 random_seed    = str( int( time.time() ) )
 csv_file['option_fit.csv']  = 'name,value\n'
 csv_file['option_fit.csv'] += f'random_seed,{random_seed}\n'
 csv_file['option_fit.csv'] += 'refit_split,false\n'
+#
 if max_number_cpu == 1 :
    csv_file['option_fit.csv'] += f'max_number_cpu,1\n'
-"""{xrst_code}
-
-option_predict.csv
-******************
-This example uses the default value for all the options in option_predict.csv.
-{xrst_code py}"""
 csv_file['option_predict.csv']  = 'name,value\n'
-"""{xrst_code}
-
-covariate.csv
-*************
-This example has one covariate called haqi.
-Other cause mortality, omega, is constant and equal to 0.02.
-The covariate only depends on the node and has values
-1.0, 0.5, 1.5 for nodes n0, n1, n2 respectively.
-{xrst_code py}"""
+#
 csv_file['covariate.csv'] = \
 '''node_name,sex,age,time,omega,haqi
 n0,female,50,2000,0.02,1.0
@@ -94,45 +42,19 @@ n0,male,50,2000,0.02,1.0
 n1,male,50,2000,0.02,0.5
 n2,male,50,2000,0.02,1.5
 '''
-"""{xrst_code}
-
-fit_goal.csv
-************
-The goal is to fit the model for nodes n1 and n2.
-{xrst_code py}"""
+#
 csv_file['fit_goal.csv'] = \
 '''node_name
 n1
 n2
 '''
-"""{xrst_code}
-
-predict_integrand.csv
-*********************
-For this example we want to know the values of Sincidence
-and prevalence for each of the goal nodes.
-(Note that Sincidence is a direct measurement of iota.)
-{xrst_code py}"""
+#
 csv_file['predict_integrand.csv'] = \
 '''integrand_name
 Sincidence
 prevalence
 '''
-"""{xrst_code}
-
-prior.csv
-*********
-We define three priors:
-
-.. csv-table::
-   :widths: auto
-   :delim: ;
-
-   uniform_1_1; a uniform distribution on [ -1, 1 ]
-   uniform_eps_1; a uniform distribution on [ 1e-6, 1 ]
-   gauss_01; a mean 0 standard deviation 1 Gaussian distribution
-
-{xrst_code py}"""
+#
 csv_file['prior.csv'] = \
 '''name,lower,upper,mean,std,density
 uniform_-1_1,-1.0,1.0,0.5,1.0,uniform
@@ -140,64 +62,22 @@ uniform_eps_1,1e-6,1.0,0.5,1.0,uniform
 gauss_01,,,0.0,1.0,gaussian
 gauss_1e-6,1e-6,10,1,0.2,gaussian
 '''
-"""{xrst_code}
-
-parent_rate.csv
-***************
-The only non-zero rates are omega and iota
-(omega is known and specified by the covariate.csv file).
-The model for iota is constant (with respect to age and time).
-Its value prior is uniform_eps_1.
-It does not have any dage or dtime priors because it is constant
-(so there are no age or time difference between grid values).
-{xrst_code py}"""
+#
 csv_file['parent_rate.csv'] = \
 '''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
 iota,0.0,0.0,gauss_1e-6,,,
 '''
-"""{xrst_code}
-
-child_rate.csv
-**************
-The child rates are random effects that represent the difference
-between the rate for a node being fit and the rate for one of its child nodes.
-These random effects are different for each child node.
-The are constant in age and time so age and time do not appear
-in child_rate.csv.
-In this example, when fitting n0, the child nodes are n1 and n2.
-When fitting n1 and n2, there are no child nodes (no random effects).
-Our prior for the random effects is gauss_01.
-{xrst_code py}"""
+#
 csv_file['child_rate.csv'] = \
 '''rate_name,value_prior
 iota,gauss_01
 '''
-r"""{xrst_code}
-
-mulcov.csv
-**********
-There is one covariate multiplier,
-it multiplies haqi and affects iota.
-The prior distribution for this multiplier is uniform\_-1,1.
-{xrst_code py}"""
+#
 csv_file['mulcov.csv'] = \
 '''covariate,type,effected,value_prior,const_value
 haqi,rate_value,iota,gauss_1e-6,
 '''
-"""{xrst_code}
-
-
-
-data_in.csv
-***********
-The data_in.csv file has one point for each combination of node and sex.
-The integrand is Sincidence (a direct measurement of iota.)
-The age interval is [20, 30] and the time interval is [2000, 2010]
-for each data point. (These do not really matter because the true iota
-for this example is constant.)
-The measurement standard deviation is 0.001 (during the fitting) and
-none of the data is held out.
-{xrst_code py}"""
+#
 header  = 'data_id, integrand_name, node_name, sex, age_lower, age_upper, '
 header += 'time_lower, time_upper, meas_value, meas_std, hold_out, '
 header += 'density_name, eta, nu'
@@ -211,33 +91,9 @@ csv_file['data_in.csv'] = header + \
 5, Sincidence, n2, male,   20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
 '''
 csv_file['data_in.csv'] = csv_file['data_in.csv'].replace(' ', '')
-"""{xrst_code}
-The measurement value meas_value is 0.0000 above and gets replaced by
-the following code:
-{xrst_literal
-   # BEGIN_MEAS_VALUE
-   # END_MEAS_VALUE
-}
-
-breakup_computation
-*******************
-Sometimes it is useful to fit some nodes, look at the results,
-and if they are good, continue the computation to the entire
-fit goal set. This will be done during if breakup_computation is true
-(see source code below):
-{xrst_code py}"""
+#
 breakup_computation = True
-"""{xrst_code}
-
-Source Code
-***********
-{xrst_literal
-   BEGIN_PROGRAM
-   END_PROGRAM
-}
-
-{xrst_end csv.break_fit_pred}
-"""
+#
 # BEGIN_PROGRAM
 #
 # computation

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: University of Washington <https://www.washington.edu>
+# SPDX-FileContributor: 2021-24 Bradley M. Bell
+# ----------------------------------------------------------------------------
+import os
+import sys
+import time
+import math
+import shutil
+import csv
+import multiprocessing
+# import at_cascade with a preference current directory version
+current_directory = os.getcwd()
+if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
+   sys.path.insert(0, current_directory)
+import at_cascade
+"""
+{xrst_begin csv.break_fit_pred}
+{xrst_spell
+   const
+   dage
+   delim
+   dtime
+   eps
+   haqi
+   meas
+   sincidence
+   std
+   uniform uniform
+}
+
+Breakup Fitting and Prediction and Run in Parallel
+##################################################
+
+csv_file
+********
+This dictionary is used to hold the data corresponding to the
+csv files for this example:
+{xrst_code py}"""
+csv_file = dict()
+"""{xrst_code}
+
+node.csv
+********
+For this example the root node, n0, has two children, n1 and n2.
+{xrst_code py}"""
+csv_file['node.csv'] = \
+'''node_name,parent_name
+n0,
+n1,n0
+n2,n0
+'''
+"""{xrst_code}
+
+option_fit.csv
+**************
+This example uses the default value for all the options in option_fit.csv
+except for:
+
+#. random_seed is chosen using the python time package
+#. refit_split is set to false
+#. max_number_cpu should be either 1 or None
+
+{xrst_code py}"""
+max_number_cpu = None
+random_seed    = str( int( time.time() ) )
+csv_file['option_fit.csv']  = 'name,value\n'
+csv_file['option_fit.csv'] += f'random_seed,{random_seed}\n'
+csv_file['option_fit.csv'] += 'refit_split,false\n'
+if max_number_cpu == 1 :
+   csv_file['option_fit.csv'] += f'max_number_cpu,1\n'
+"""{xrst_code}
+
+option_predict.csv
+******************
+This example uses the default value for all the options in option_predict.csv.
+{xrst_code py}"""
+csv_file['option_predict.csv']  = 'name,value\n'
+"""{xrst_code}
+
+covariate.csv
+*************
+This example has one covariate called haqi.
+Other cause mortality, omega, is constant and equal to 0.02.
+The covariate only depends on the node and has values
+1.0, 0.5, 1.5 for nodes n0, n1, n2 respectively.
+{xrst_code py}"""
+csv_file['covariate.csv'] = \
+'''node_name,sex,age,time,omega,haqi
+n0,female,50,2000,0.02,1.0
+n1,female,50,2000,0.02,0.5
+n2,female,50,2000,0.02,1.5
+n0,male,50,2000,0.02,1.0
+n1,male,50,2000,0.02,0.5
+n2,male,50,2000,0.02,1.5
+'''
+"""{xrst_code}
+
+fit_goal.csv
+************
+The goal is to fit the model for nodes n1 and n2.
+{xrst_code py}"""
+csv_file['fit_goal.csv'] = \
+'''node_name
+n1
+n2
+'''
+"""{xrst_code}
+
+predict_integrand.csv
+*********************
+For this example we want to know the values of Sincidence
+and prevalence for each of the goal nodes.
+(Note that Sincidence is a direct measurement of iota.)
+{xrst_code py}"""
+csv_file['predict_integrand.csv'] = \
+'''integrand_name
+Sincidence
+prevalence
+'''
+"""{xrst_code}
+
+prior.csv
+*********
+We define three priors:
+
+.. csv-table::
+   :widths: auto
+   :delim: ;
+
+   uniform_1_1; a uniform distribution on [ -1, 1 ]
+   uniform_eps_1; a uniform distribution on [ 1e-6, 1 ]
+   gauss_01; a mean 0 standard deviation 1 Gaussian distribution
+
+{xrst_code py}"""
+csv_file['prior.csv'] = \
+'''name,lower,upper,mean,std,density
+uniform_-1_1,-1.0,1.0,0.5,1.0,uniform
+uniform_eps_1,1e-6,1.0,0.5,1.0,uniform
+gauss_01,,,0.0,1.0,gaussian
+'''
+"""{xrst_code}
+
+parent_rate.csv
+***************
+The only non-zero rates are omega and iota
+(omega is known and specified by the covariate.csv file).
+The model for iota is constant (with respect to age and time).
+Its value prior is uniform_eps_1.
+It does not have any dage or dtime priors because it is constant
+(so there are no age or time difference between grid values).
+{xrst_code py}"""
+csv_file['parent_rate.csv'] = \
+'''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
+iota,0.0,0.0,uniform_eps_1,,,
+'''
+"""{xrst_code}
+
+child_rate.csv
+**************
+The child rates are random effects that represent the difference
+between the rate for a node being fit and the rate for one of its child nodes.
+These random effects are different for each child node.
+The are constant in age and time so age and time do not appear
+in child_rate.csv.
+In this example, when fitting n0, the child nodes are n1 and n2.
+When fitting n1 and n2, there are no child nodes (no random effects).
+Our prior for the random effects is gauss_01.
+{xrst_code py}"""
+csv_file['child_rate.csv'] = \
+'''rate_name,value_prior
+iota,gauss_01
+'''
+r"""{xrst_code}
+
+mulcov.csv
+**********
+There is one covariate multiplier,
+it multiplies haqi and affects iota.
+The prior distribution for this multiplier is uniform\_-1,1.
+{xrst_code py}"""
+csv_file['mulcov.csv'] = \
+'''covariate,type,effected,value_prior,const_value
+haqi,rate_value,iota,uniform_-1_1,
+'''
+"""{xrst_code}
+
+
+
+data_in.csv
+***********
+The data_in.csv file has one point for each combination of node and sex.
+The integrand is Sincidence (a direct measurement of iota.)
+The age interval is [20, 30] and the time interval is [2000, 2010]
+for each data point. (These do not really matter because the true iota
+for this example is constant.)
+The measurement standard deviation is 0.001 (during the fitting) and
+none of the data is held out.
+{xrst_code py}"""
+header  = 'data_id, integrand_name, node_name, sex, age_lower, age_upper, '
+header += 'time_lower, time_upper, meas_value, meas_std, hold_out, '
+header += 'density_name, eta, nu'
+csv_file['data_in.csv'] = header + \
+'''
+0, Sincidence, n0, female, 0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
+1, Sincidence, n0, male,   0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
+2, Sincidence, n1, female, 10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
+3, Sincidence, n1, male,   10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
+4, Sincidence, n2, female, 20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
+5, Sincidence, n2, male,   20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
+'''
+csv_file['data_in.csv'] = csv_file['data_in.csv'].replace(' ', '')
+"""{xrst_code}
+The measurement value meas_value is 0.0000 above and gets replaced by
+the following code:
+{xrst_literal
+   # BEGIN_MEAS_VALUE
+   # END_MEAS_VALUE
+}
+
+breakup_computation
+*******************
+Sometimes it is useful to fit some nodes, look at the results,
+and if they are good, continue the computation to the entire
+fit goal set. This will be done during if breakup_computation is true
+(see source code below):
+{xrst_code py}"""
+breakup_computation = True
+"""{xrst_code}
+
+Source Code
+***********
+{xrst_literal
+   BEGIN_PROGRAM
+   END_PROGRAM
+}
+
+{xrst_end csv.break_fit_pred}
+"""
+# BEGIN_PROGRAM
+#
+# computation
+def computation(fit_dir) :
+   #
+   # csv.fit, csv.predict
+   if not breakup_computation:
+      at_cascade.csv.fit(fit_dir)
+      at_cascade.csv.predict(fit_dir)
+   else :
+      # csv.fit: Just fit the root node
+      # Since refit_split is false, this will only fit include n0.both.
+      at_cascade.csv.fit(fit_dir, max_node_depth = 0)
+      #
+      # all_node_database
+      all_node_database = f'{fit_dir}/all_node.db'
+      #
+      # Run two continues starting at n0.both.
+      # If max_number_cpu != 1, run them in parallel.
+      # p_fit
+      p_fit = dict()
+      fit_node_database = f'{fit_dir}/n0/dismod.db'
+      fit_type          = [ 'both', 'fixed']
+      for node_name in [ 'n1' , 'n2' ] :
+         fit_goal_set  = { node_name }
+         shared_unique = '_' + node_name
+         args          = (
+            all_node_database,
+            fit_node_database,
+            fit_goal_set,
+            fit_type,
+            shared_unique,
+         )
+         if max_number_cpu == 1 :
+            at_cascade.continue_cascade( *args )
+         else :
+            p_fit[node_name] = multiprocessing.Process(
+               target = at_cascade.continue_cascade , args = args ,
+            )
+            p_fit[node_name].start()
+      #
+      # Run one predict for n0.both using this process
+      # If max_number_cpu != 1, this is in parallel with the continues above
+      p_predict      = dict()
+      sim_dir        = None
+      start_job_name = 'n0.both'
+      max_job_depth  = 0
+      args            = (fit_dir, sim_dir, start_job_name, max_job_depth)
+      at_cascade.csv.predict( *args )
+      #
+      # If max_number_cpu != 1, wait for continue jobs to finish
+      for key in p_fit :
+         p_fit[key].join()
+      #
+      #
+      # Run predict starting at
+      # n1.female, n1.male, n2.female, n2.male.
+      # If max_number_cpu != 1, run them in parallel.
+      sim_dir       = None
+      max_job_depth = 1
+      for node_name in [ 'n1', 'n2' ] :
+         for sex in [ 'female', 'male' ] :
+            start_job_name = f'{node_name}.{sex}'
+            args           = (fit_dir, sim_dir, start_job_name, max_job_depth)
+            if max_number_cpu == 1 :
+               at_cascade.csv.predict(*args)
+            else :
+               p_predict[sex] = multiprocessing.Process(
+                  target = at_cascade.csv.predict, args = args,
+                )
+               p_predict[sex].start()
+      #
+      # If max_number_cpu != 1, wait for predict jobs to finish
+      for key in p_predict :
+         p_predict[key].join()
+      #
+      # predict
+      # fit_predict.csv, sam_predict.csv
+      for prefix in [ 'fit' , 'sam' ] :
+         file_name = f'{fit_dir}/{prefix}_predict.csv'
+         file_out  = open(file_name, 'w')
+         writer    = None
+         for start_job_name in [
+            'n0.both', 'n1.female', 'n1.male', 'n2.female', 'n2.male'
+         ] :
+            file_name = f'{fit_dir}/predict/{prefix}_{start_job_name}.csv'
+            file_in   = open(file_name, 'r')
+            reader    = csv.DictReader(file_in)
+            for row in reader :
+               if writer == None :
+                  writer = csv.DictWriter(file_out, fieldnames = row.keys() )
+                  writer.writeheader()
+               writer.writerow(row)
+         file_out.close()
+   return
+#
+# main
+def main() :
+   #
+   # fit_dir
+   fit_dir = 'build/example/csv'
+   at_cascade.empty_directory(fit_dir)
+   #
+   # write csv files
+   for name in csv_file :
+      file_name = f'{fit_dir}/{name}'
+      file_ptr  = open(file_name, 'w')
+      file_ptr.write( csv_file[name] )
+      file_ptr.close()
+   #
+   # node2haqi, haqi_avg
+   node2haqi  = { 'n0' : 1.0, 'n1' : 0.5, 'n2' : 1.5 }
+   file_name  = f'{fit_dir}/covariate.csv'
+   table      = at_cascade.csv.read_table( file_name )
+   haqi_sum   = 0.0
+   for row in table :
+      node_name = row['node_name']
+      haqi      = float( row['haqi'] )
+      haqi_sum += haqi
+      assert haqi == node2haqi[node_name]
+   haqi_avg = haqi_sum / len(table)
+   #
+   # data_in.csv
+   float_format      = '{0:.5g}'
+   true_mulcov_haqi  = 0.5
+   no_effect_iota    = 0.1
+   file_name         = f'{fit_dir}/data_in.csv'
+   table             = at_cascade.csv.read_table( file_name )
+   for row in table :
+      node_name      = row['node_name']
+      integrand_name = row['integrand_name']
+      assert integrand_name == 'Sincidence'
+      #
+      # BEGIN_MEAS_VALUE
+      haqi              = node2haqi[node_name]
+      effect            = true_mulcov_haqi * (haqi - haqi_avg)
+      iota              = math.exp(effect) * no_effect_iota
+      row['meas_value'] = float_format.format( iota )
+      # END_MEAS_VALUE
+   at_cascade.csv.write_table(file_name, table)
+   #
+   # computation
+   computation(fit_dir)
+   #
+   # prefix
+   for prefix in [ 'fit' , 'sam' ] :
+      #
+      # predict_table
+      file_name = f'{fit_dir}/{prefix}_predict.csv'
+      predict_table = at_cascade.csv.read_table(file_name)
+      #
+      # node
+      for node in [ 'n0', 'n1', 'n2' ] :
+         # sex
+         for sex in [ 'female', 'both', 'male' ] :
+            #
+            # sample_list
+            sample_list = list()
+            for row in predict_table :
+               if row['integrand_name'] == 'Sincidence' and \
+                     row['node_name'] == node and \
+                        row['sex'] == sex :
+                  #
+                  sample_list.append(row)
+            if node == 'n0' and sex == 'both' :
+               assert len(sample_list) != 0
+            elif node != 'n0' and sex != 'both' :
+               assert len(sample_list) != 0
+            else :
+               assert len(sample_list) == 0
+            #
+            if len(sample_list) > 0 :
+               sum_avgint = 0.0
+               for row in sample_list :
+                  sum_avgint   += float( row['avg_integrand'] )
+               avgint    = sum_avgint / len(sample_list)
+               haqi      = float( row['haqi'] )
+               effect    = true_mulcov_haqi * (haqi - haqi_avg)
+               iota      = math.exp(effect) * no_effect_iota
+               rel_error = (avgint - iota) / iota
+               assert abs(rel_error) < 0.01
+   print('break_fit_pred.py: OK')
+#
+main()
+# END_PROGRAM

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -16,7 +16,7 @@ if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
 import at_cascade
 import dismod_at
 """
-{xrst_begin csv.break_fit_pred}
+{xrst_begin csv.prior_pred}
 {xrst_spell
    const
    dage

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -9,13 +9,14 @@ import math
 import shutil
 import csv
 import multiprocessing
+import dismod_at
 # import at_cascade with a preference current directory version
 current_directory = os.getcwd()
 if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
    sys.path.insert(0, current_directory)
 import at_cascade
 """
-{xrst_begin csv.break_fit_pred}
+{xrst_begin prior_pred.py}
 {xrst_spell
    const
    dage
@@ -29,396 +30,34 @@ import at_cascade
    uniform uniform
 }
 
-Breakup Fitting and Prediction and Run in Parallel
-##################################################
-
-csv_file
-********
-This dictionary is used to hold the data corresponding to the
-csv files for this example:
-{xrst_code py}"""
-csv_file = dict()
-"""{xrst_code}
-
-node.csv
-********
-For this example the root node, n0, has two children, n1 and n2.
-{xrst_code py}"""
-csv_file['node.csv'] = \
-'''node_name,parent_name
-n0,
-n1,n0
-n2,n0
-'''
-"""{xrst_code}
-
-option_fit.csv
-**************
-This example uses the default value for all the options in option_fit.csv
-except for:
-
-#. random_seed is chosen using the python time package
-#. refit_split is set to false
-#. max_number_cpu should be either 1 or None
-
-{xrst_code py}"""
-max_number_cpu = None
-random_seed    = str( int( time.time() ) )
-csv_file['option_fit.csv']  = 'name,value\n'
-csv_file['option_fit.csv'] += f'random_seed,{random_seed}\n'
-csv_file['option_fit.csv'] += 'refit_split,false\n'
-if max_number_cpu == 1 :
-   csv_file['option_fit.csv'] += f'max_number_cpu,1\n'
-"""{xrst_code}
-
-option_predict.csv
-******************
-This example uses the default value for all the options in option_predict.csv.
-{xrst_code py}"""
-csv_file['option_predict.csv']  = 'name,value\n'
-"""{xrst_code}
-
-covariate.csv
-*************
-This example has one covariate called haqi.
-Other cause mortality, omega, is constant and equal to 0.02.
-The covariate only depends on the node and has values
-1.0, 0.5, 1.5 for nodes n0, n1, n2 respectively.
-{xrst_code py}"""
-csv_file['covariate.csv'] = \
-'''node_name,sex,age,time,omega,haqi
-n0,female,50,2000,0.02,1.0
-n1,female,50,2000,0.02,0.5
-n2,female,50,2000,0.02,1.5
-n0,male,50,2000,0.02,1.0
-n1,male,50,2000,0.02,0.5
-n2,male,50,2000,0.02,1.5
-'''
-"""{xrst_code}
-
-fit_goal.csv
-************
-The goal is to fit the model for nodes n1 and n2.
-{xrst_code py}"""
-csv_file['fit_goal.csv'] = \
-'''node_name
-n1
-n2
-'''
-"""{xrst_code}
-
-predict_integrand.csv
-*********************
-For this example we want to know the values of Sincidence
-and prevalence for each of the goal nodes.
-(Note that Sincidence is a direct measurement of iota.)
-{xrst_code py}"""
-csv_file['predict_integrand.csv'] = \
-'''integrand_name
-Sincidence
-prevalence
-'''
-"""{xrst_code}
-
-prior.csv
-*********
-We define three priors:
-
-.. csv-table::
-   :widths: auto
-   :delim: ;
-
-   uniform_1_1; a uniform distribution on [ -1, 1 ]
-   uniform_eps_1; a uniform distribution on [ 1e-6, 1 ]
-   gauss_01; a mean 0 standard deviation 1 Gaussian distribution
-
-{xrst_code py}"""
-csv_file['prior.csv'] = \
-'''name,lower,upper,mean,std,density
-uniform_-1_1,-1.0,1.0,0.5,1.0,uniform
-uniform_eps_1,1e-6,1.0,0.5,1.0,uniform
-gauss_01,,,0.0,1.0,gaussian
-'''
-"""{xrst_code}
-
-parent_rate.csv
-***************
-The only non-zero rates are omega and iota
-(omega is known and specified by the covariate.csv file).
-The model for iota is constant (with respect to age and time).
-Its value prior is uniform_eps_1.
-It does not have any dage or dtime priors because it is constant
-(so there are no age or time difference between grid values).
-{xrst_code py}"""
-csv_file['parent_rate.csv'] = \
-'''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
-iota,0.0,0.0,uniform_eps_1,,,
-'''
-"""{xrst_code}
-
-child_rate.csv
-**************
-The child rates are random effects that represent the difference
-between the rate for a node being fit and the rate for one of its child nodes.
-These random effects are different for each child node.
-The are constant in age and time so age and time do not appear
-in child_rate.csv.
-In this example, when fitting n0, the child nodes are n1 and n2.
-When fitting n1 and n2, there are no child nodes (no random effects).
-Our prior for the random effects is gauss_01.
-{xrst_code py}"""
-csv_file['child_rate.csv'] = \
-'''rate_name,value_prior
-iota,gauss_01
-'''
-r"""{xrst_code}
-
-mulcov.csv
-**********
-There is one covariate multiplier,
-it multiplies haqi and affects iota.
-The prior distribution for this multiplier is uniform\_-1,1.
-{xrst_code py}"""
-csv_file['mulcov.csv'] = \
-'''covariate,type,effected,value_prior,const_value
-haqi,rate_value,iota,uniform_-1_1,
-'''
-"""{xrst_code}
-
-
-
-data_in.csv
-***********
-The data_in.csv file has one point for each combination of node and sex.
-The integrand is Sincidence (a direct measurement of iota.)
-The age interval is [20, 30] and the time interval is [2000, 2010]
-for each data point. (These do not really matter because the true iota
-for this example is constant.)
-The measurement standard deviation is 0.001 (during the fitting) and
-none of the data is held out.
-{xrst_code py}"""
-header  = 'data_id, integrand_name, node_name, sex, age_lower, age_upper, '
-header += 'time_lower, time_upper, meas_value, meas_std, hold_out, '
-header += 'density_name, eta, nu'
-csv_file['data_in.csv'] = header + \
-'''
-0, Sincidence, n0, female, 0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
-1, Sincidence, n0, male,   0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
-2, Sincidence, n1, female, 10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
-3, Sincidence, n1, male,   10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
-4, Sincidence, n2, female, 20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
-5, Sincidence, n2, male,   20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
-'''
-csv_file['data_in.csv'] = csv_file['data_in.csv'].replace(' ', '')
-"""{xrst_code}
-The measurement value meas_value is 0.0000 above and gets replaced by
-the following code:
-{xrst_literal
-   # BEGIN_MEAS_VALUE
-   # END_MEAS_VALUE
-}
-
-breakup_computation
-*******************
-Sometimes it is useful to fit some nodes, look at the results,
-and if they are good, continue the computation to the entire
-fit goal set. This will be done during if breakup_computation is true
-(see source code below):
-{xrst_code py}"""
-breakup_computation = True
-"""{xrst_code}
-
-Source Code
-***********
-{xrst_literal
-   BEGIN_PROGRAM
-   END_PROGRAM
-}
-
-{xrst_end csv.break_fit_pred}
+{xrst_end prior_pred.py}
 """
-# BEGIN_PROGRAM
+
+"""
+Make temp.py section into a module, which is called by the test. Get that
+passing the test, then build on the function and integrate it into predict.py
+after.
+
+Later: Try refactoring predict.py so it can predict off either priors or
+posteriors, and lets us use the existing parallelizations etc. without
+reinventing the wheel. Flag if we use ancestor.db or the no-data prior.db and
+the flag switches which is being used. Have the outputs from predict.py go to
+subdirectories depending on whether they're from prior or from posterior. We may
+need to support predicting from both at the same time.
+"""
+current_directory = os.getcwd()
+# sys.path.insert(0, current_directory)
+import at_cascade
 #
-# computation
-def computation(fit_dir) :
-   #
-   # csv.fit, csv.predict
-   if not breakup_computation:
-      at_cascade.csv.fit(fit_dir)
-      at_cascade.csv.predict(fit_dir)
-   else :
-      # csv.fit: Just fit the root node
-      # Since refit_split is false, this will only fit include n0.both.
-      at_cascade.csv.fit(fit_dir, max_node_depth = 0)
-      #
-      # all_node_database
-      all_node_database = f'{fit_dir}/all_node.db'
-      #
-      # Run two continues starting at n0.both.
-      # If max_number_cpu != 1, run them in parallel.
-      # p_fit
-      p_fit = dict()
-      fit_node_database = f'{fit_dir}/n0/dismod.db'
-      fit_type          = [ 'both', 'fixed']
-      for node_name in [ 'n1' , 'n2' ] :
-         fit_goal_set  = { node_name }
-         shared_unique = '_' + node_name
-         args          = (
-            all_node_database,
-            fit_node_database,
-            fit_goal_set,
-            fit_type,
-            shared_unique,
-         )
-         if max_number_cpu == 1 :
-            at_cascade.continue_cascade( *args )
-         else :
-            p_fit[node_name] = multiprocessing.Process(
-               target = at_cascade.continue_cascade , args = args ,
-            )
-            p_fit[node_name].start()
-      #
-      # Run one predict for n0.both using this process
-      # If max_number_cpu != 1, this is in parallel with the continues above
-      p_predict      = dict()
-      sim_dir        = None
-      start_job_name = 'n0.both'
-      max_job_depth  = 0
-      args            = (fit_dir, sim_dir, start_job_name, max_job_depth)
-      at_cascade.csv.predict( *args )
-      #
-      # If max_number_cpu != 1, wait for continue jobs to finish
-      for key in p_fit :
-         p_fit[key].join()
-      #
-      #
-      # Run predict starting at
-      # n1.female, n1.male, n2.female, n2.male.
-      # If max_number_cpu != 1, run them in parallel.
-      sim_dir       = None
-      max_job_depth = 1
-      for node_name in [ 'n1', 'n2' ] :
-         for sex in [ 'female', 'male' ] :
-            start_job_name = f'{node_name}.{sex}'
-            args           = (fit_dir, sim_dir, start_job_name, max_job_depth)
-            if max_number_cpu == 1 :
-               at_cascade.csv.predict(*args)
-            else :
-               p_predict[sex] = multiprocessing.Process(
-                  target = at_cascade.csv.predict, args = args,
-                )
-               p_predict[sex].start()
-      #
-      # If max_number_cpu != 1, wait for predict jobs to finish
-      for key in p_predict :
-         p_predict[key].join()
-      #
-      # predict
-      # fit_predict.csv, sam_predict.csv
-      for prefix in [ 'fit' , 'sam' ] :
-         file_name = f'{fit_dir}/{prefix}_predict.csv'
-         file_out  = open(file_name, 'w')
-         writer    = None
-         for start_job_name in [
-            'n0.both', 'n1.female', 'n1.male', 'n2.female', 'n2.male'
-         ] :
-            file_name = f'{fit_dir}/predict/{prefix}_{start_job_name}.csv'
-            file_in   = open(file_name, 'r')
-            reader    = csv.DictReader(file_in)
-            for row in reader :
-               if writer == None :
-                  writer = csv.DictWriter(file_out, fieldnames = row.keys() )
-                  writer.writeheader()
-               writer.writerow(row)
-         file_out.close()
-   return
+# example/csv/break_fit_pred.py
+command = [ 'python3', 'example/csv/break_fit_pred.py' ] 
+if True :
+   dismod_at.system_command_prc(command)
 #
-# main
-def main() :
-   #
-   # fit_dir
-   fit_dir = 'build/example/csv'
-   at_cascade.empty_directory(fit_dir)
-   #
-   # write csv files
-   for name in csv_file :
-      file_name = f'{fit_dir}/{name}'
-      file_ptr  = open(file_name, 'w')
-      file_ptr.write( csv_file[name] )
-      file_ptr.close()
-   #
-   # node2haqi, haqi_avg
-   node2haqi  = { 'n0' : 1.0, 'n1' : 0.5, 'n2' : 1.5 }
-   file_name  = f'{fit_dir}/covariate.csv'
-   table      = at_cascade.csv.read_table( file_name )
-   haqi_sum   = 0.0
-   for row in table :
-      node_name = row['node_name']
-      haqi      = float( row['haqi'] )
-      haqi_sum += haqi
-      assert haqi == node2haqi[node_name]
-   haqi_avg = haqi_sum / len(table)
-   #
-   # data_in.csv
-   float_format      = '{0:.5g}'
-   true_mulcov_haqi  = 0.5
-   no_effect_iota    = 0.1
-   file_name         = f'{fit_dir}/data_in.csv'
-   table             = at_cascade.csv.read_table( file_name )
-   for row in table :
-      node_name      = row['node_name']
-      integrand_name = row['integrand_name']
-      assert integrand_name == 'Sincidence'
-      #
-      # BEGIN_MEAS_VALUE
-      haqi              = node2haqi[node_name]
-      effect            = true_mulcov_haqi * (haqi - haqi_avg)
-      iota              = math.exp(effect) * no_effect_iota
-      row['meas_value'] = float_format.format( iota )
-      # END_MEAS_VALUE
-   at_cascade.csv.write_table(file_name, table)
-   #
-   # computation
-   computation(fit_dir)
-   #
-   # prefix
-   for prefix in [ 'fit' , 'sam' ] :
-      #
-      # predict_table
-      file_name = f'{fit_dir}/{prefix}_predict.csv'
-      predict_table = at_cascade.csv.read_table(file_name)
-      #
-      # node
-      for node in [ 'n0', 'n1', 'n2' ] :
-         # sex
-         for sex in [ 'female', 'both', 'male' ] :
-            #
-            # sample_list
-            sample_list = list()
-            for row in predict_table :
-               if row['integrand_name'] == 'Sincidence' and \
-                     row['node_name'] == node and \
-                        row['sex'] == sex :
-                  #
-                  sample_list.append(row)
-            if node == 'n0' and sex == 'both' :
-               assert len(sample_list) != 0
-            elif node != 'n0' and sex != 'both' :
-               assert len(sample_list) != 0
-            else :
-               assert len(sample_list) == 0
-            #
-            if len(sample_list) > 0 :
-               sum_avgint = 0.0
-               for row in sample_list :
-                  sum_avgint   += float( row['avg_integrand'] )
-               avgint    = sum_avgint / len(sample_list)
-               haqi      = float( row['haqi'] )
-               effect    = true_mulcov_haqi * (haqi - haqi_avg)
-               iota      = math.exp(effect) * no_effect_iota
-               rel_error = (avgint - iota) / iota
-               assert abs(rel_error) < 0.01
-   print('break_fit_pred.py: OK')
+print('\n\n =============== BEGIN prior_pred.py =============== \n\n')
 #
-main()
-# END_PROGRAM
+# Run our new prior prediction module
+command = [ 'python3', 'at_cascade/csv/predict_prior.py' ] 
+if True :
+   dismod_at.system_command_prc(command)
+print('prior_pred.py: OK')

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -55,9 +55,6 @@ if True :
    dismod_at.system_command_prc(command)
 #
 print('\n\n =============== BEGIN prior_pred.py =============== \n\n')
-#
-# Run our new prior prediction module
-command = [ 'python3', 'at_cascade/csv/predict_prior.py' ] 
-if True :
-   dismod_at.system_command_prc(command)
+at_cascade.csv.predict_prior(
+   fit_dir=os.path.join(current_directory, 'build/example/csv'))
 print('prior_pred.py: OK')

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -14,15 +14,55 @@ current_directory = os.getcwd()
 if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
    sys.path.insert(0, current_directory)
 import at_cascade
-#
+import dismod_at
+"""
+{xrst_begin csv.break_fit_pred}
+{xrst_spell
+   const
+   dage
+   delim
+   dtime
+   eps
+   haqi
+   meas
+   sincidence
+   std
+   uniform uniform
+}
+
+Predict Fit Values and Samples for Priors
+#########################################
+
+csv_file
+********
+This dictionary is used to hold the data corresponding to the
+csv files for this example:
+{xrst_code py}"""
 csv_file = dict()
+"""{xrst_code}
+
+node.csv
+********
+For this example the root node, n0, has two children, n1 and n2.
+{xrst_code py}"""
 csv_file['node.csv'] = \
 '''node_name,parent_name
 n0,
 n1,n0
 n2,n0
 '''
-#
+"""{xrst_code}
+
+option_fit.csv
+**************
+This example uses the default value for all the options in option_fit.csv
+except for:
+
+#. random_seed is chosen using the python time package
+#. refit_split is set to false
+#. max_number_cpu should be either 1 or None
+
+{xrst_code py}"""
 max_number_cpu = None
 random_seed    = str( int( time.time() ) )
 csv_file['option_fit.csv']  = 'name,value\n'
@@ -31,53 +71,136 @@ csv_file['option_fit.csv'] += 'refit_split,false\n'
 #
 if max_number_cpu == 1 :
    csv_file['option_fit.csv'] += f'max_number_cpu,1\n'
+"""{xrst_code}
+
+option_predict.csv
+******************
+This example uses the default value for all the options in option_predict.csv.
+{xrst_code py}"""
 csv_file['option_predict.csv']  = 'name,value\n'
-#
+"""{xrst_code}
+
+covariate.csv
+*************
+This example has one covariate called haqi.
+Other cause mortality, omega, is constant and equal to 0.02.
+The covariate only depends on the node and is held constant
+at 1.0.
+{xrst_code py}"""
 csv_file['covariate.csv'] = \
 '''node_name,sex,age,time,omega,haqi
-n0,female,50,2000,0.02,1.0
-n1,female,50,2000,0.02,0.5
-n2,female,50,2000,0.02,1.5
-n0,male,50,2000,0.02,1.0
-n1,male,50,2000,0.02,0.5
-n2,male,50,2000,0.02,1.5
+n0,female,50,2000,0.002,1.0
+n1,female,50,2000,0.002,1.0
+n2,female,50,2000,0.002,1.0
+n0,male,50,2000,0.002,1.0
+n1,male,50,2000,0.002,1.0
+n2,male,50,2000,0.002,1.0
 '''
-#
+"""{xrst_code}
+
+fit_goal.csv
+************
+The goal is to fit the model for nodes n1 and n2.
+{xrst_code py}"""
 csv_file['fit_goal.csv'] = \
 '''node_name
 n1
 n2
 '''
-#
+"""{xrst_code}
+
+predict_integrand.csv
+*********************
+For this example we want to know the values of Sincidence
+and prevalence for each of the goal nodes.
+(Note that Sincidence is a direct measurement of iota.)
+{xrst_code py}"""
 csv_file['predict_integrand.csv'] = \
 '''integrand_name
 Sincidence
 prevalence
 '''
-#
+"""{xrst_code}
+
+prior.csv
+*********
+We define four priors:
+
+.. csv-table::
+   :widths: auto
+   :delim: ;
+
+   uniform_1_1; a uniform distribution on [ -1, 1 ]
+   uniform_eps_1; a uniform distribution on [ 1e-6, 1 ]
+   gauss_01; a mean 0 standard deviation 1 Gaussian distribution
+   gauss_1e-6: a mean 0.1, standard deviation 0.02 Gaussian distribution on [1e-6, 10]
+
+{xrst_code py}"""
 csv_file['prior.csv'] = \
 '''name,lower,upper,mean,std,density
 uniform_-1_1,-1.0,1.0,0.5,1.0,uniform
 uniform_eps_1,1e-6,1.0,0.5,1.0,uniform
-gauss_01,,,0.0,1.0,gaussian
-gauss_1e-6,1e-6,10,1,0.2,gaussian
+gauss_01,,,0.0,0.05,gaussian
+gauss_1e-6,1e-6,10,0.1,0.02,gaussian
 '''
-#
+"""{xrst_code}
+
+parent_rate.csv
+***************
+The only non-zero rates are omega and iota
+(omega is known and specified by the covariate.csv file).
+The model for iota is constant (with respect to age and time).
+Its value prior is gauss_1e-6.
+It does not have any dage or dtime priors because it is constant
+(so there are no age or time difference between grid values).
+{xrst_code py}"""
 csv_file['parent_rate.csv'] = \
 '''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
 iota,0.0,0.0,gauss_1e-6,,,
 '''
-#
+"""{xrst_code}
+
+child_rate.csv
+**************
+The child rates are random effects that represent the difference
+between the rate for a node being fit and the rate for one of its child nodes.
+These random effects are different for each child node.
+The are constant in age and time so age and time do not appear
+in child_rate.csv.
+In this example, when fitting n0, the child nodes are n1 and n2.
+When fitting n1 and n2, there are no child nodes (no random effects).
+Our prior for the random effects is gauss_01.
+{xrst_code py}"""
 csv_file['child_rate.csv'] = \
 '''rate_name,value_prior
 iota,gauss_01
 '''
-#
+r"""{xrst_code}
+
+mulcov.csv
+**********
+There is one covariate multiplier,
+it multiplies haqi and affects iota.
+The prior distribution for this multiplier is gauss_1e-6.
+{xrst_code py}"""
 csv_file['mulcov.csv'] = \
 '''covariate,type,effected,value_prior,const_value
 haqi,rate_value,iota,gauss_1e-6,
 '''
-#
+"""{xrst_code}
+
+
+
+data_in.csv
+***********
+The data_in.csv file has one point for each combination of node and sex.
+The integrand is Sincidence (a direct measurement of iota.)
+The age interval is [20, 30] and the time interval is [2000, 2010]
+for each data point. (These do not really matter because the true iota
+for this example is constant.)
+The measurement standard deviation is 0.001 (during the fitting) and
+none of the data is held out.
+{xrst_code py}"""
 header  = 'data_id, integrand_name, node_name, sex, age_lower, age_upper, '
 header += 'time_lower, time_upper, meas_value, meas_std, hold_out, '
 header += 'density_name, eta, nu'
@@ -91,110 +214,24 @@ csv_file['data_in.csv'] = header + \
 5, Sincidence, n2, male,   20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
 '''
 csv_file['data_in.csv'] = csv_file['data_in.csv'].replace(' ', '')
-#
-breakup_computation = True
-#
+"""{xrst_code}
+The measurement value meas_value is 0.0000 above and gets replaced by
+the following code:
+{xrst_literal
+   # BEGIN_MEAS_VALUE
+   # END_MEAS_VALUE
+}
+
+Source Code
+***********
+{xrst_literal
+   BEGIN_PROGRAM
+   END_PROGRAM
+}
+
+{xrst_end csv.prior_pred}
+"""
 # BEGIN_PROGRAM
-#
-# computation
-def computation(fit_dir) :
-   #
-   # csv.fit, csv.predict_prior
-   print("entered computation")
-   if not breakup_computation:
-      at_cascade.csv.fit(fit_dir)
-      at_cascade.csv.predict_prior(fit_dir)
-   else :
-      print("entered else")
-      # csv.fit: Just fit the root node
-      # Since refit_split is false, this will only fit include n0.both.
-      at_cascade.csv.fit(fit_dir, max_node_depth = 0)
-      #
-      # all_node_database
-      all_node_database = f'{fit_dir}/all_node.db'
-      #
-      # Run two continues starting at n0.both.
-      # If max_number_cpu != 1, run them in parallel.
-      # p_fit
-      p_fit = dict()
-      fit_node_database = f'{fit_dir}/n0/dismod.db'
-      fit_type          = [ 'both', 'fixed']
-      for node_name in [ 'n1' , 'n2' ] :
-         fit_goal_set  = { node_name }
-         shared_unique = '_' + node_name
-         args          = (
-            all_node_database,
-            fit_node_database,
-            fit_goal_set,
-            fit_type,
-            shared_unique,
-         )
-         if max_number_cpu == 1 :
-            at_cascade.continue_cascade( *args )
-         else :
-            p_fit[node_name] = multiprocessing.Process(
-               target = at_cascade.continue_cascade , args = args ,
-            )
-            p_fit[node_name].start()
-      #
-      # Run one predict for n0.both using this process
-      # If max_number_cpu != 1, this is in parallel with the continues above
-      p_predict      = dict()
-      sim_dir        = None
-      start_job_name = 'n0.both'
-      max_job_depth  = 0
-      args            = ( fit_dir, )
-      print("args = ", *args)
-      print("calling predict_prior")
-      at_cascade.csv.predict_prior( *args )
-      print("finished predict_prior call")
-      #
-      # If max_number_cpu != 1, wait for continue jobs to finish
-      for key in p_fit :
-         p_fit[key].join()
-      #
-      #
-      # Run predict starting at
-      # n1.female, n1.male, n2.female, n2.male.
-      # If max_number_cpu != 1, run them in parallel.
-      sim_dir       = None
-      max_job_depth = 1
-      for node_name in [ 'n1', 'n2' ] :
-         for sex in [ 'female', 'male' ] :
-            start_job_name = f'{node_name}.{sex}'
-            args           = ( fit_dir, )
-            if max_number_cpu == 1 :
-               at_cascade.csv.predict_prior(*args)
-            else :
-               key            = (node_name, sex)
-               p_predict[key] = multiprocessing.Process(
-                  target = at_cascade.csv.predict_prior, args = args
-                )
-               p_predict[key].start()
-      #
-      # If max_number_cpu != 1, wait for predict jobs to finish
-      for key in p_predict :
-         p_predict[key].join()
-      #
-      # # predict
-      # # fit_predict.csv, sam_predict.csv
-      # for prefix in [ 'fit' , 'sam' ] :
-      #    file_name = f'{fit_dir}/{prefix}_predict.csv'
-      #    file_out  = open(file_name, 'w')
-      #    writer    = None
-      #    for start_job_name in [
-      #       'n0.both', 'n1.female', 'n1.male', 'n2.female', 'n2.male'
-      #    ] :
-      #       file_name = f'{fit_dir}/predict/{prefix}_{start_job_name}.csv'
-      #       file_in   = open(file_name, 'r')
-      #       reader    = csv.DictReader(file_in)
-      #       for row in reader :
-      #          if writer == None :
-      #             writer = csv.DictWriter(file_out, fieldnames = row.keys() )
-      #             writer.writeheader()
-      #          writer.writerow(row)
-      #    file_out.close()
-   return
 #
 # main
 def main() :
@@ -211,7 +248,7 @@ def main() :
       file_ptr.close()
    #
    # node2haqi, haqi_avg
-   node2haqi  = { 'n0' : 1.0, 'n1' : 0.5, 'n2' : 1.5 }
+   node2haqi  = { 'n0' : 1.0, 'n1' : 1.0, 'n2' : 1.0 }
    file_name  = f'{fit_dir}/covariate.csv'
    table      = at_cascade.csv.read_table( file_name )
    haqi_sum   = 0.0
@@ -225,7 +262,7 @@ def main() :
    # data_in.csv
    float_format      = '{0:.5g}'
    true_mulcov_haqi  = 0.5
-   no_effect_iota    = 0.1
+   no_effect_iota    = 0.5
    file_name         = f'{fit_dir}/data_in.csv'
    table             = at_cascade.csv.read_table( file_name )
    for row in table :
@@ -241,47 +278,50 @@ def main() :
       # END_MEAS_VALUE
    at_cascade.csv.write_table(file_name, table)
    #
-   # computation
-   computation(fit_dir)
+   # fit
+   at_cascade.csv.fit(fit_dir)
+   #
+   # predict_prior
+   at_cascade.csv.predict_prior(fit_dir)
    #
    # prefix
-   # for prefix in [ 'fit' , 'sam' ] :
-   #    #
-   #    # predict_table
-   #    file_name = f'{fit_dir}/{prefix}_predict.csv'
-   #    predict_table = at_cascade.csv.read_table(file_name)
-   #    #
-   #    # node
-   #    for node in [ 'n0', 'n1', 'n2' ] :
-   #       # sex
-   #       for sex in [ 'female', 'both', 'male' ] :
-   #          #
-   #          # sample_list
-   #          sample_list = list()
-   #          for row in predict_table :
-   #             if row['integrand_name'] == 'Sincidence' and \
-   #                   row['node_name'] == node and \
-   #                      row['sex'] == sex :
-   #                #
-   #                sample_list.append(row)
-   #          if node == 'n0' and sex == 'both' :
-   #             assert len(sample_list) != 0
-   #          elif node != 'n0' and sex != 'both' :
-   #             assert len(sample_list) != 0
-   #          else :
-   #             assert len(sample_list) == 0
-   #          #
-   #          if len(sample_list) > 0 :
-   #             sum_avgint = 0.0
-   #             for row in sample_list :
-   #                sum_avgint   += float( row['avg_integrand'] )
-   #             avgint    = sum_avgint / len(sample_list)
-   #             haqi      = float( row['haqi'] )
-   #             effect    = true_mulcov_haqi * (haqi - haqi_avg)
-   #             iota      = math.exp(effect) * no_effect_iota
-   #             rel_error = (avgint - iota) / iota
-   #             assert abs(rel_error) < 0.01
-   print('prior_pred.py: OK')
+   for prefix in [ 'fit' , 'sam' ] :
+      #
+      # node
+      for node in [ 'n0', 'n1', 'n2' ] :
+         # sex
+         for sex in [ 'female', 'both', 'male' ] :
+            #
+            # sample_list
+            # predict_table
+            file_name = f'{fit_dir}/{prefix}_predict.csv'
+            predict_table = at_cascade.csv.read_table(file_name)
+            #
+            sample_list = list()
+            for row in predict_table :
+               if row['integrand_name'] == "Sincidence" and \
+                     row['node_name'] == node and \
+                        row['sex'] == sex :
+                           sample_list.append(row)
+            if node == 'n0' and sex == 'both' :
+               assert len(sample_list) != 0
+            elif node != 'n0' and sex != 'both' :
+               assert len(sample_list) != 0
+            else :
+               assert len(sample_list) == 0
+            #
+            if len(sample_list) > 0 :
+               sum_avgint = 0.0
+               for row in sample_list :
+                  sum_avgint   += float( row['avg_integrand'] )
+               avgint    = sum_avgint / len(sample_list)
+               haqi      = float( row['haqi'] )
+               effect    = true_mulcov_haqi * (haqi - haqi_avg)
+               iota      = math.exp(effect) * no_effect_iota
+               rel_error = (avgint - iota) / iota
+               assert abs(rel_error) < 0.01
 #
-main()
+if __name__ == '__main__' :
+   main()
+   print('prior_pred.py: OK')
 # END_PROGRAM

--- a/example/csv/prior_pred.py
+++ b/example/csv/prior_pred.py
@@ -9,14 +9,13 @@ import math
 import shutil
 import csv
 import multiprocessing
-import dismod_at
 # import at_cascade with a preference current directory version
 current_directory = os.getcwd()
 if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
    sys.path.insert(0, current_directory)
 import at_cascade
 """
-{xrst_begin prior_pred.py}
+{xrst_begin csv.break_fit_pred}
 {xrst_spell
    const
    dage
@@ -30,31 +29,401 @@ import at_cascade
    uniform uniform
 }
 
-{xrst_end prior_pred.py}
-"""
+Breakup Fitting and Prediction and Run in Parallel
+##################################################
 
-"""
-Make temp.py section into a module, which is called by the test. Get that
-passing the test, then build on the function and integrate it into predict.py
-after.
+csv_file
+********
+This dictionary is used to hold the data corresponding to the
+csv files for this example:
+{xrst_code py}"""
+csv_file = dict()
+"""{xrst_code}
 
-Later: Try refactoring predict.py so it can predict off either priors or
-posteriors, and lets us use the existing parallelizations etc. without
-reinventing the wheel. Flag if we use ancestor.db or the no-data prior.db and
-the flag switches which is being used. Have the outputs from predict.py go to
-subdirectories depending on whether they're from prior or from posterior. We may
-need to support predicting from both at the same time.
+node.csv
+********
+For this example the root node, n0, has two children, n1 and n2.
+{xrst_code py}"""
+csv_file['node.csv'] = \
+'''node_name,parent_name
+n0,
+n1,n0
+n2,n0
+'''
+"""{xrst_code}
+
+option_fit.csv
+**************
+This example uses the default value for all the options in option_fit.csv
+except for:
+
+#. random_seed is chosen using the python time package
+#. refit_split is set to false
+#. max_number_cpu should be either 1 or None
+
+{xrst_code py}"""
+max_number_cpu = None
+random_seed    = str( int( time.time() ) )
+csv_file['option_fit.csv']  = 'name,value\n'
+csv_file['option_fit.csv'] += f'random_seed,{random_seed}\n'
+csv_file['option_fit.csv'] += 'refit_split,false\n'
+if max_number_cpu == 1 :
+   csv_file['option_fit.csv'] += f'max_number_cpu,1\n'
+"""{xrst_code}
+
+option_predict.csv
+******************
+This example uses the default value for all the options in option_predict.csv.
+{xrst_code py}"""
+csv_file['option_predict.csv']  = 'name,value\n'
+"""{xrst_code}
+
+covariate.csv
+*************
+This example has one covariate called haqi.
+Other cause mortality, omega, is constant and equal to 0.02.
+The covariate only depends on the node and has values
+1.0, 0.5, 1.5 for nodes n0, n1, n2 respectively.
+{xrst_code py}"""
+csv_file['covariate.csv'] = \
+'''node_name,sex,age,time,omega,haqi
+n0,female,50,2000,0.02,1.0
+n1,female,50,2000,0.02,0.5
+n2,female,50,2000,0.02,1.5
+n0,male,50,2000,0.02,1.0
+n1,male,50,2000,0.02,0.5
+n2,male,50,2000,0.02,1.5
+'''
+"""{xrst_code}
+
+fit_goal.csv
+************
+The goal is to fit the model for nodes n1 and n2.
+{xrst_code py}"""
+csv_file['fit_goal.csv'] = \
+'''node_name
+n1
+n2
+'''
+"""{xrst_code}
+
+predict_integrand.csv
+*********************
+For this example we want to know the values of Sincidence
+and prevalence for each of the goal nodes.
+(Note that Sincidence is a direct measurement of iota.)
+{xrst_code py}"""
+csv_file['predict_integrand.csv'] = \
+'''integrand_name
+Sincidence
+prevalence
+'''
+"""{xrst_code}
+
+prior.csv
+*********
+We define three priors:
+
+.. csv-table::
+   :widths: auto
+   :delim: ;
+
+   uniform_1_1; a uniform distribution on [ -1, 1 ]
+   uniform_eps_1; a uniform distribution on [ 1e-6, 1 ]
+   gauss_01; a mean 0 standard deviation 1 Gaussian distribution
+
+{xrst_code py}"""
+csv_file['prior.csv'] = \
+'''name,lower,upper,mean,std,density
+uniform_-1_1,-1.0,1.0,0.5,1.0,uniform
+uniform_eps_1,1e-6,1.0,0.5,1.0,uniform
+gauss_01,,,0.0,1.0,gaussian
+'''
+"""{xrst_code}
+
+parent_rate.csv
+***************
+The only non-zero rates are omega and iota
+(omega is known and specified by the covariate.csv file).
+The model for iota is constant (with respect to age and time).
+Its value prior is uniform_eps_1.
+It does not have any dage or dtime priors because it is constant
+(so there are no age or time difference between grid values).
+{xrst_code py}"""
+csv_file['parent_rate.csv'] = \
+'''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
+iota,0.0,0.0,uniform_eps_1,,,
+'''
+"""{xrst_code}
+
+child_rate.csv
+**************
+The child rates are random effects that represent the difference
+between the rate for a node being fit and the rate for one of its child nodes.
+These random effects are different for each child node.
+The are constant in age and time so age and time do not appear
+in child_rate.csv.
+In this example, when fitting n0, the child nodes are n1 and n2.
+When fitting n1 and n2, there are no child nodes (no random effects).
+Our prior for the random effects is gauss_01.
+{xrst_code py}"""
+csv_file['child_rate.csv'] = \
+'''rate_name,value_prior
+iota,gauss_01
+'''
+r"""{xrst_code}
+
+mulcov.csv
+**********
+There is one covariate multiplier,
+it multiplies haqi and affects iota.
+The prior distribution for this multiplier is uniform\_-1,1.
+{xrst_code py}"""
+csv_file['mulcov.csv'] = \
+'''covariate,type,effected,value_prior,const_value
+haqi,rate_value,iota,uniform_-1_1,
+'''
+"""{xrst_code}
+
+
+
+data_in.csv
+***********
+The data_in.csv file has one point for each combination of node and sex.
+The integrand is Sincidence (a direct measurement of iota.)
+The age interval is [20, 30] and the time interval is [2000, 2010]
+for each data point. (These do not really matter because the true iota
+for this example is constant.)
+The measurement standard deviation is 0.001 (during the fitting) and
+none of the data is held out.
+{xrst_code py}"""
+header  = 'data_id, integrand_name, node_name, sex, age_lower, age_upper, '
+header += 'time_lower, time_upper, meas_value, meas_std, hold_out, '
+header += 'density_name, eta, nu'
+csv_file['data_in.csv'] = header + \
+'''
+0, Sincidence, n0, female, 0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
+1, Sincidence, n0, male,   0,  10, 1990, 2000, 0.0000, 0.001, 0, gaussian, ,
+2, Sincidence, n1, female, 10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
+3, Sincidence, n1, male,   10, 20, 2000, 2010, 0.0000, 0.001, 0, gaussian, ,
+4, Sincidence, n2, female, 20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
+5, Sincidence, n2, male,   20, 30, 2010, 2020, 0.0000, 0.001, 0, gaussian, ,
+'''
+csv_file['data_in.csv'] = csv_file['data_in.csv'].replace(' ', '')
+"""{xrst_code}
+The measurement value meas_value is 0.0000 above and gets replaced by
+the following code:
+{xrst_literal
+   # BEGIN_MEAS_VALUE
+   # END_MEAS_VALUE
+}
+
+breakup_computation
+*******************
+Sometimes it is useful to fit some nodes, look at the results,
+and if they are good, continue the computation to the entire
+fit goal set. This will be done during if breakup_computation is true
+(see source code below):
+{xrst_code py}"""
+breakup_computation = True
+"""{xrst_code}
+
+Source Code
+***********
+{xrst_literal
+   BEGIN_PROGRAM
+   END_PROGRAM
+}
+
+{xrst_end csv.break_fit_pred}
 """
-current_directory = os.getcwd()
-# sys.path.insert(0, current_directory)
-import at_cascade
+# BEGIN_PROGRAM
 #
-# example/csv/break_fit_pred.py
-command = [ 'python3', 'example/csv/break_fit_pred.py' ] 
-if True :
-   dismod_at.system_command_prc(command)
+# computation
+def computation(fit_dir) :
+   #
+   # csv.fit, csv.predict_prior
+   print("entered computation")
+   if not breakup_computation:
+      at_cascade.csv.fit(fit_dir)
+      at_cascade.csv.predict_prior(fit_dir)
+   else :
+      print("entered else")
+      # csv.fit: Just fit the root node
+      # Since refit_split is false, this will only fit include n0.both.
+      at_cascade.csv.fit(fit_dir, max_node_depth = 0)
+      #
+      # all_node_database
+      all_node_database = f'{fit_dir}/all_node.db'
+      #
+      # Run two continues starting at n0.both.
+      # If max_number_cpu != 1, run them in parallel.
+      # p_fit
+      p_fit = dict()
+      fit_node_database = f'{fit_dir}/n0/dismod.db'
+      fit_type          = [ 'both', 'fixed']
+      for node_name in [ 'n1' , 'n2' ] :
+         fit_goal_set  = { node_name }
+         shared_unique = '_' + node_name
+         args          = (
+            all_node_database,
+            fit_node_database,
+            fit_goal_set,
+            fit_type,
+            shared_unique,
+         )
+         if max_number_cpu == 1 :
+            at_cascade.continue_cascade( *args )
+         else :
+            p_fit[node_name] = multiprocessing.Process(
+               target = at_cascade.continue_cascade , args = args ,
+            )
+            p_fit[node_name].start()
+      #
+      # Run one predict for n0.both using this process
+      # If max_number_cpu != 1, this is in parallel with the continues above
+      p_predict      = dict()
+      sim_dir        = None
+      start_job_name = 'n0.both'
+      max_job_depth  = 0
+      args            = (fit_dir, sim_dir, start_job_name, max_job_depth)
+      print("calling predict_prior")
+      at_cascade.csv.predict_prior( *args )
+      print("finished predict_prior call")
+      #
+      # If max_number_cpu != 1, wait for continue jobs to finish
+      for key in p_fit :
+         p_fit[key].join()
+      #
+      #
+      # Run predict starting at
+      # n1.female, n1.male, n2.female, n2.male.
+      # If max_number_cpu != 1, run them in parallel.
+      sim_dir       = None
+      max_job_depth = 1
+      for node_name in [ 'n1', 'n2' ] :
+         for sex in [ 'female', 'male' ] :
+            start_job_name = f'{node_name}.{sex}'
+            args           = (fit_dir, sim_dir, start_job_name, max_job_depth)
+            if max_number_cpu == 1 :
+               at_cascade.csv.predict_prior(*args)
+            else :
+               key            = (node_name, sex)
+               p_predict[key] = multiprocessing.Process(
+                  target = at_cascade.csv.predict_prior, args = args,
+                )
+               p_predict[key].start()
+      #
+      # If max_number_cpu != 1, wait for predict jobs to finish
+      for key in p_predict :
+         p_predict[key].join()
+      #
+      # predict
+      # fit_predict.csv, sam_predict.csv
+      for prefix in [ 'fit' , 'sam' ] :
+         file_name = f'{fit_dir}/{prefix}_predict.csv'
+         file_out  = open(file_name, 'w')
+         writer    = None
+         for start_job_name in [
+            'n0.both', 'n1.female', 'n1.male', 'n2.female', 'n2.male'
+         ] :
+            file_name = f'{fit_dir}/predict/{prefix}_{start_job_name}.csv'
+            file_in   = open(file_name, 'r')
+            reader    = csv.DictReader(file_in)
+            for row in reader :
+               if writer == None :
+                  writer = csv.DictWriter(file_out, fieldnames = row.keys() )
+                  writer.writeheader()
+               writer.writerow(row)
+         file_out.close()
+   return
 #
-print('\n\n =============== BEGIN prior_pred.py =============== \n\n')
-at_cascade.csv.predict_prior(
-   fit_dir=os.path.join(current_directory, 'build/example/csv'))
-print('prior_pred.py: OK')
+# main
+def main() :
+   #
+   # fit_dir
+   fit_dir = 'build/example/csv'
+   at_cascade.empty_directory(fit_dir)
+   #
+   # write csv files
+   for name in csv_file :
+      file_name = f'{fit_dir}/{name}'
+      file_ptr  = open(file_name, 'w')
+      file_ptr.write( csv_file[name] )
+      file_ptr.close()
+   #
+   # node2haqi, haqi_avg
+   node2haqi  = { 'n0' : 1.0, 'n1' : 0.5, 'n2' : 1.5 }
+   file_name  = f'{fit_dir}/covariate.csv'
+   table      = at_cascade.csv.read_table( file_name )
+   haqi_sum   = 0.0
+   for row in table :
+      node_name = row['node_name']
+      haqi      = float( row['haqi'] )
+      haqi_sum += haqi
+      assert haqi == node2haqi[node_name]
+   haqi_avg = haqi_sum / len(table)
+   #
+   # data_in.csv
+   float_format      = '{0:.5g}'
+   true_mulcov_haqi  = 0.5
+   no_effect_iota    = 0.1
+   file_name         = f'{fit_dir}/data_in.csv'
+   table             = at_cascade.csv.read_table( file_name )
+   for row in table :
+      node_name      = row['node_name']
+      integrand_name = row['integrand_name']
+      assert integrand_name == 'Sincidence'
+      #
+      # BEGIN_MEAS_VALUE
+      haqi              = node2haqi[node_name]
+      effect            = true_mulcov_haqi * (haqi - haqi_avg)
+      iota              = math.exp(effect) * no_effect_iota
+      row['meas_value'] = float_format.format( iota )
+      # END_MEAS_VALUE
+   at_cascade.csv.write_table(file_name, table)
+   #
+   # computation
+   computation(fit_dir)
+   #
+   # prefix
+   for prefix in [ 'fit' , 'sam' ] :
+      #
+      # predict_table
+      file_name = f'{fit_dir}/{prefix}_predict.csv'
+      predict_table = at_cascade.csv.read_table(file_name)
+      #
+      # node
+      for node in [ 'n0', 'n1', 'n2' ] :
+         # sex
+         for sex in [ 'female', 'both', 'male' ] :
+            #
+            # sample_list
+            sample_list = list()
+            for row in predict_table :
+               if row['integrand_name'] == 'Sincidence' and \
+                     row['node_name'] == node and \
+                        row['sex'] == sex :
+                  #
+                  sample_list.append(row)
+            if node == 'n0' and sex == 'both' :
+               assert len(sample_list) != 0
+            elif node != 'n0' and sex != 'both' :
+               assert len(sample_list) != 0
+            else :
+               assert len(sample_list) == 0
+            #
+            if len(sample_list) > 0 :
+               sum_avgint = 0.0
+               for row in sample_list :
+                  sum_avgint   += float( row['avg_integrand'] )
+               avgint    = sum_avgint / len(sample_list)
+               haqi      = float( row['haqi'] )
+               effect    = true_mulcov_haqi * (haqi - haqi_avg)
+               iota      = math.exp(effect) * no_effect_iota
+               rel_error = (avgint - iota) / iota
+               assert abs(rel_error) < 0.01
+   print('prior_pred.py: OK')
+#
+main()
+# END_PROGRAM

--- a/example/example.xrst
+++ b/example/example.xrst
@@ -20,6 +20,7 @@ The at_cascade Examples
    example/csv/join_file_xam.py
    example/csv/population.py
    example/csv/prevalence2iota.py
+   example/csv/prior_pred.py
    example/csv/shock_cov.py
    example/csv/sim_fit_pred.py
    example/csv/simulate_xam.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # ----------------------------------------------------------------------------
 [project]
 name              = 'at_cascade'
-version           = '2024.7.31'
+version           = '2024.8.18'
 description       = 'Cascading dismod_at from parent to child regions'
 license           = { text = 'AGPL-3.0-or-later' }
 requires-python   = '>=3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # ----------------------------------------------------------------------------
 [project]
 name              = 'at_cascade'
-version           = '2024.8.18'
+version           = '2024.8.19'
 description       = 'Cascading dismod_at from parent to child regions'
 license           = { text = 'AGPL-3.0-or-later' }
 requires-python   = '>=3.8'

--- a/test/csv/sample_fail.py
+++ b/test/csv/sample_fail.py
@@ -3,6 +3,7 @@
 # SPDX-FileContributor: 2021-24 Bradley M. Bell
 # ----------------------------------------------------------------------------
 # Test prdictions when on of the fits or samples fails.
+# This also tests predictions when a there is no data for a fit.
 #
 import os
 import sys
@@ -32,6 +33,7 @@ csv_file['option_predict.csv'] = \
 '''name,value
 db2csv,true
 plot,true
+max_number_cpu,1
 '''
 #
 # node.csv

--- a/xrst/release_notes.xrst
+++ b/xrst/release_notes.xrst
@@ -35,6 +35,11 @@ Release Notes for 2024
 mm-dd
 *****
 
+08-18
+=====
+Add special ``at_cascade`` log messages to mark the progress of the fitting
+operation; see :ref:`fit_one_job@fit_node_database@log` for ``fit_one_job`` .
+
 07-30
 =====
 It the IHME cluster is reporting errors like

--- a/xrst/release_notes.xrst
+++ b/xrst/release_notes.xrst
@@ -37,8 +37,10 @@ mm-dd
 
 08-18
 =====
-Add special ``at_cascade`` log messages to mark the progress of the fitting
-operation; see :ref:`fit_one_job@fit_node_database@log` for ``fit_one_job`` .
+#. Add special ``at_cascade`` log messages to mark the progress of the fitting
+   operation; see :ref:`fit_one_job@fit_node_database@log` for ``fit_one_job`` .
+#. Change fit_one_job so that it aborts the fit when there is no data;
+   see :ref:`fit_one_job@fit_node_database@log` .
 
 07-30
 =====

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -14,19 +14,6 @@
 Wish List for at_cascade
 ########################
 
-Predict with start_job_id below failing node
-********************************************
-Change :ref:`at_cascade/check_log.py` so that it will check logs starting 
-from the root_node. Currently check_log.py only checks logs starting from 
-the start_job_id and continuing down the cascade. This creates a case in 
-which the at_cascade.csv.predict function may generate bad ancestor.db files
-if the parent location of start_job_id fails to fit.
-
-Surface integrand table in at_cascade docs
-******************************************
-Add the integrand table found in https://dismod-at.readthedocs.io/integrand_table.html
-to the AT_Cascade docs for better visibility for end users of AT-Cascade
-
 avgint Table
 ************
 Change :ref:`cascade_root_node-name` so that upon return

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -14,6 +14,14 @@
 Wish List for at_cascade
 ########################
 
+Predict with start_job_id below failing node
+********************************************
+Change :ref:`at_cascade/check_log.py` so that it will check logs starting 
+from the root_node. Currently check_log.py only checks logs starting from 
+the start_job_id and continuing down the cascade. This creates a case in 
+which the at_cascade.csv.predict function may generate bad ancestor.db files
+if the parent location of start_job_id fails to fit.
+
 avgint Table
 ************
 Change :ref:`cascade_root_node-name` so that upon return

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -22,6 +22,11 @@ the start_job_id and continuing down the cascade. This creates a case in
 which the at_cascade.csv.predict function may generate bad ancestor.db files
 if the parent location of start_job_id fails to fit.
 
+Surface integrand table in at_cascade docs
+******************************************
+Add the integrand table found in https://dismod-at.readthedocs.io/integrand_table.html
+to the AT_Cascade docs for better visibility for end users of AT-Cascade
+
 avgint Table
 ************
 Change :ref:`cascade_root_node-name` so that upon return


### PR DESCRIPTION
New PR building from #16.

# Changes
- Add initial go at a new module, `at_cascade/csv/predict_prior.py`, for predicting from priors.
- Add example `example/csv/prior_pred.py` which tests predicting from priors.

# Planned further changes
- `example/csv/prior_pred.py` needs documentation. The current file was built based on `example/csv/break_fit_pred.py` but the xrst has been removed and it needs to be re-added to fit the new example.