### PR TITLE
add fit and predict number of samples to wish list

### DIFF
--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -66,6 +66,12 @@ See Priors for Each Fit
 =======================
 Outputting prior std or samples so we have uncertainty of the priors.
 
+Allow Different Numbers of Samples for Fit and Predict
+======================================================
+Independently specify the number of samples used during fitting and predicting.
+This would help reduce file size, potentially significantly, if the samples are
+possible to decouple.
+
 Retry Fit
 =========
 Sometimes a particular fit fails due to insufficient memory or similar problem.


### PR DESCRIPTION
# Changes
## wish_list.xrst
- Add new item wishing for a way to specify the number of samples used in fit separately from the number used in predicting. This was motivated primarily by file size worries, cascade fits with many nodes and large numbers of samples (100+) can consume a lot of storage space.

# Tests
Ran `bin/run_xrst.sh` and got no errors:
```
$ bin/run_xrst.sh
xrst --local_toc --target html --html_theme sphinx_rtd_theme --index_page_name at_cascade 
Using following input_files: git ls-files
sphinx-build -b html -j 1 build/rst build/html
rm -r build/html/_sources
cp -r build/rst/_sources build/html/_sources
xrst: OK
run_xrst.sh: OK
$
```
# Notes
I expect this'll be another feature me & Nate try to tackle in the future, but wanted to add it to the list so it's tracked in the same place as all the other items. I'm also not 100% certain this will prove possible, eg if the predict samples depend on the fit samples, but need to know more about whether/how prediction samples depend on fit samples.