### PR TITLE
move log open_connection

### DIFF
--- a/at_cascade/fit_one_job.py
+++ b/at_cascade/fit_one_job.py
@@ -288,11 +288,6 @@ def fit_one_job(
    parent_node_name = at_cascade.get_parent_node(fit_node_database)
    assert parent_node_name == node_table[fit_node_id]['node_name']
    #
-   # connection
-   connection = dismod_at.create_connection(
-      fit_node_database, new = False, readonly = False
-   )
-   #
    # integrand_table
    root_node_database = option_all_dict['root_node_database']
    fit_or_root        = at_cascade.fit_or_root_class(
@@ -378,6 +373,13 @@ def fit_one_job(
       job_table         = job_table         ,
       fit_job_id        = run_job_id        ,
    )
+   #
+   # connection
+   connection = dismod_at.create_connection(
+      fit_node_database, new = False, readonly = False
+   )
+   #
+   # log avgint_parent_grid
    at_cascade.add_log_entry(connection, 'avgint_parent_grid')
    #
    # c_shift_predict_fit_var


### PR DESCRIPTION
Move the `open_connection` call during the fit process until after optimization to reduce the opportunity for intermittent database problems stemming from holding the connection open.