### PR TITLE
Wish list: Add item to refit only nodes which have data

### DIFF
--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -14,6 +14,16 @@
 Wish List for at_cascade
 ########################
 
+Re-fit only locations with data during cascade
+**********************************************
+Currently at_cascade performs a fit at each node in the cascade whether the node
+has data or not. Adding a feature which activates when a node has no data and
+does not perform a new fit for that node, instead using the node's prior as the
+fit, under the reasoning that there's no new information to update the prior, 
+could speed up large cascades and potentially avoid issues where a node with no
+data gets re-fit with a wide prior, allowing the re-fit to wander from the prior
+despite having no information driving the change.
+
 avgint Table
 ************
 Change :ref:`cascade_root_node-name` so that upon return

--- a/xrst/wish_list.xrst
+++ b/xrst/wish_list.xrst
@@ -14,8 +14,8 @@
 Wish List for at_cascade
 ########################
 
-Re-fit only locations with data during cascade
-**********************************************
+Re-fit only nodes with data
+***************************
 Currently at_cascade performs a fit at each node in the cascade whether the node
 has data or not. Adding a feature which activates when a node has no data and
 does not perform a new fit for that node, instead using the node's prior as the


### PR DESCRIPTION
# Changes

Add a new wish list item RE only fitting nodes which have data, and use node's prior predictions as its fit if there is no data for that node.

It's possible for a node which has no data to have its fit differ significantly from its prior despite having no new data, which this would prevent.

# Checks

`bin/run_xrst.sh` passed with the following output:
```
$ bin/run_xrst.sh
xrst --local_toc --target html --html_theme sphinx_rtd_theme --index_page_name at_cascade 
Using following input_files: git ls-files
sphinx-build -b html -j 1 build/rst build/html
rm -r build/html/_sources
cp -r build/rst/_sources build/html/_sources
xrst: OK
run_xrst.sh: OK
$ 
```