### PR TITLE
Fix: Add more data points to test/csv/fit.py and test/csv/sample_fail.py to prevent data plots from failing to save

### DIFF
--- a/test/csv/fit.py
+++ b/test/csv/fit.py
@@ -121,9 +121,13 @@ csv_file['data_in.csv'] = header + \
 0,Sincidence,n0,both,0,10,1990,2000,0.00,1e-4,0,gaussian,,
 1,Sincidence,n0,both,0,10,1990,2000,0.00,1e-4,0,gaussian,,
 2,Sincidence,n1,female,10,20,2000,2010,0.00,1e-4,0,gaussian,,
-3,Sincidence,n1,male,10,20,2000,2010,0.00,1e-4,0,gaussian,,
-4,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
-5,Sincidence,n2,male,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+3,Sincidence,n1,female,10,20,2000,2010,0.00,1e-4,0,gaussian,,
+4,Sincidence,n1,male,10,20,2000,2010,0.00,1e-4,0,gaussian,,
+5,Sincidence,n1,male,10,20,2000,2010,0.00,1e-4,0,gaussian,,
+6,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+7,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+8,Sincidence,n2,male,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+9,Sincidence,n2,male,20,30,2010,2020,0.00,1e-4,0,gaussian,,
 '''
 
 #

--- a/test/csv/sample_fail.py
+++ b/test/csv/sample_fail.py
@@ -98,7 +98,9 @@ csv_file['data_in.csv'] = header + \
 '''
 0,Sincidence,n0,female,0,10,1990,2000,0.00,1e-4,0,gaussian,,
 1,Sincidence,n1,female,10,20,2000,2010,0.00,1e-4,0,gaussian,,
-2,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+2,Sincidence,n1,female,10,20,2000,2010,0.00,1e-4,0,gaussian,,
+3,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
+4,Sincidence,n2,female,20,30,2010,2020,0.00,1e-4,0,gaussian,,
 '''
 
 #


### PR DESCRIPTION
# Problem

Tests `test/csv/fit.py` and `test/csv/sample_fail.py` fail with matplotlib v3.10.0.

# Cause

Matplotlib recently released [v3.10.0](https://github.com/matplotlib/matplotlib/releases/tag/v3.10.0), which changed the behavior of the `subfigure` routine. Now if all subfigures are empty, it will not save to a file (previously a file with empty subfigures would be saved).

The tests `test/csv/fit.py` and `test/csv/sample_fail.py` each use one data point per leaf node in their test data.csv sets. This results in empty subfigures being produced due to a conditional in [`dismod_at.plot_data_fit()`](https://github.com/bradbell/dismod_at/blob/master/python/dismod_at/plot_data_fit.py#L262) that fills subplots only if `n_point - n_hold_out > 1`. Since these tests use single data points for leaf nodes, the conditional puts nothing in their data subplots, producing all empty subfigures, resulting in no file being saved due to the matplotlib change, which causes the tests to fail when asserting that data plot files exist.

This was confirmed to be due to the matplotlib change by @ntemiq by using matplotlib [v3.9.3](https://github.com/matplotlib/matplotlib/releases/tag/v3.9.3), for which `bin/check_all.sh` ran to completion with no issues.

# Solution

Add a second (duplicate) data point to each leaf node in the test `data.csv` for both `test/csv/fit.py` and `test/csv/sample_fail.py`.

# Checks

With these changes `bin/check_all.sh` now runs to completion with no errors. Log file of the output from my run is: [check_all.log](https://github.com/user-attachments/files/18352451/check_all.log).

