### PR TITLE
Feature: Number sample predict

### DIFF
--- a/at_cascade/csv/predict.py
+++ b/at_cascade/csv/predict.py
@@ -133,6 +133,12 @@ multipliers are set to zero during the predictions
 (instead of their simulation values, fit, or sample values).
 The default value for this option is false .
 
+number_sample_predict
+---------------------
+This integer option specifies the number of samples generated for each
+prediction. If not set, :ref:`csv.fit@Input Files@option_fit.csv@number_sample`
+from :ref:`csv.fit@Input Files@option_fit.csv` will be used.
+
 covariate.csv
 =============
 Same as the csv fit

--- a/at_cascade/csv/predict.py
+++ b/at_cascade/csv/predict.py
@@ -356,7 +356,7 @@ def ancestor_set(node_table, node_id) :
 # has been coverted to its corresponding type.
 #
 global_option_value = None
-def set_global_option_value(fit_dir, option_table, top_node_name) :
+def set_global_option_value(fit_dir, option_table, number_sample_fit, top_node_name) :
    global global_option_value
    assert type(global_option_value) == dict or global_option_value == None
    assert type(option_table) == list
@@ -378,6 +378,7 @@ def set_global_option_value(fit_dir, option_table, top_node_name) :
       'db2csv'                : (bool,  False)              ,
       'float_precision'       : (int,   5)                  ,
       'max_number_cpu'        : (int,   max_number_cpu)     ,
+      'number_sample_predict' : (int,   number_sample_fit)                 ,
       'plot'                  : (bool,  False)              ,
       'zero_meas_value'       : (bool,  False)              ,
    }
@@ -475,8 +476,10 @@ def predict(fit_dir, sim_dir=None, start_job_name=None, max_job_depth=None) :
    #
    # global_option_value
    option_table = at_cascade.csv.read_table(f'{fit_dir}/option_predict.csv')
+   option_fit_table = at_cascade.csv.read_table(f'{fit_dir}/option_fit_out.csv')
+   number_sample_fit = option_fit_table["name" == "number_sample"]["value"]
    set_global_option_value(
-      fit_dir, option_table, top_node_name
+      fit_dir, option_table, number_sample_fit, top_node_name
    )
    #
    # start_node_name

--- a/test/csv/number_sample_predict.py
+++ b/test/csv/number_sample_predict.py
@@ -169,5 +169,5 @@ def main() :
 #
 if __name__ == '__main__' :
    main()
-   print('csv_fit.py: OK')
+   print('number_sample_predict.py: OK')
 # END_PYTHON

--- a/test/csv/number_sample_predict.py
+++ b/test/csv/number_sample_predict.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: University of Washington <https://www.washington.edu>
+# SPDX-FileContributor: 2021-24 Bradley M. Bell
+# ----------------------------------------------------------------------------
+import os
+import sys
+import time
+import math
+import shutil
+# import at_cascade with a preference current directory version
+current_directory = os.getcwd()
+if os.path.isfile( current_directory + '/at_cascade/__init__.py' ) :
+   sys.path.insert(0, current_directory)
+import at_cascade
+# BEGIN_PYTHON
+#
+# no_effect_iota_true
+no_effect_iota_true    = 0.01
+#
+# csv_file
+csv_file = dict()
+#
+# option_fit.csv
+random_seed = str( int( time.time() ) )
+csv_file['option_fit.csv'] = \
+'''name,value
+max_abs_effect,3.0
+number_sample,10
+sample_method,asymptotic
+no_ode_ignore,iota
+root_node_name,n0
+absolute_covariates,young
+'''
+#
+# option_predict.csv
+random_seed = str( int( time.time() ) )
+csv_file['option_predict.csv'] = \
+'''name,value
+db2csv,true
+plot,true
+number_sample_predict,20
+'''
+#
+# node.csv
+# Use node n-1 to test starting below the base of the tree
+csv_file['node.csv'] = \
+'''node_name,parent_name
+n0,
+n1,n0
+'''
+#
+# covariate.csv
+csv_file['covariate.csv'] = \
+'''node_name,sex,age,time,young,omega
+n0,female,20,2000,1.0,0.02
+n0,female,80,2000,0.0,0.02
+n0,male,20,2000,1.0,0.02
+n0,male,80,2000,0.0,0.02
+n1,female,20,2000,1.0,0.02
+n1,female,80,2000,0.0,0.02
+n1,male,20,2000,1.0,0.02
+n1,male,80,2000,0.0,0.02
+'''
+#
+# fit_goal.csv
+# n-1 is not included in test because it is not below the root node n0
+csv_file['fit_goal.csv'] = \
+'''node_name
+n1
+'''
+#
+# predict_integrand.csv
+csv_file['predict_integrand.csv'] = \
+'''integrand_name
+Sincidence
+'''
+#
+# prior.csv
+csv_file['prior.csv'] = \
+'''name,lower,upper,std,density,mean
+uniform_-2_2,-2.0,2.0,10.0,uniform,0.0
+gauss_eps_10,1e-6,1.0,100.0,gaussian,'''
+csv_file['prior.csv'] += str( no_effect_iota_true )
+#
+# parent_rate.csv
+csv_file['parent_rate.csv'] = \
+'''rate_name,age,time,value_prior,dage_prior,dtime_prior,const_value
+iota,0.0,0.0,gauss_eps_10,,,
+'''
+#
+# child_rate.csv
+csv_file['child_rate.csv'] = \
+'''rate_name,value_prior
+'''
+#
+# mulcov.csv
+csv_file['mulcov.csv'] = \
+'''covariate,type,effected,value_prior,const_value
+young,meas_value,Sincidence,uniform_-2_2,
+'''
+#
+# data_in.csv
+# The 0.00 meas_value and meas_std in this table get replaced
+header  = 'data_id,integrand_name,node_name,sex,age_lower,age_upper,'
+header += 'time_lower,time_upper,meas_value,meas_std,hold_out,'
+header += 'density_name,eta,nu'
+csv_file['data_in.csv'] = header + \
+'''
+0,Sincidence,n0,both,10,10,2000,2000,0.00,0.00,0,gaussian,,
+1,Sincidence,n0,both,80,80,2000,2000,0.00,0.00,0,gaussian,,
+'''
+
+#
+#
+def main() :
+   #
+   # fit_dir
+   fit_dir = 'build/test/csv'
+   at_cascade.empty_directory(fit_dir)
+   #
+   # write csv files
+   for name in csv_file :
+      file_name = f'{fit_dir}/{name}'
+      file_ptr  = open(file_name, 'w')
+      file_ptr.write( csv_file[name] )
+      file_ptr.close()
+   #
+   # table
+   file_name  = f'{fit_dir}/covariate.csv'
+   table      = at_cascade.csv.read_table( file_name )
+   #
+   # data_in.csv
+   float_format        = '{0:.8g}'
+   mulcov_young_true   = 0.5
+   file_name           = f'{fit_dir}/data_in.csv'
+   table               = at_cascade.csv.read_table( file_name )
+   for row in table :
+      age            = float(row['age_lower'])
+      young          = float( age < 20 )
+      integrand_name = row['integrand_name']
+      assert integrand_name == 'Sincidence'
+      #
+      effect            = mulcov_young_true * young
+      Sincidence        = math.exp(effect) * no_effect_iota_true
+      row['meas_value'] = float_format.format( Sincidence )
+      row['meas_std']   = float_format.format( Sincidence / 10.0 )
+   at_cascade.csv.write_table(file_name, table)
+   #
+   # csv.fit, csv.predict
+   at_cascade.csv.fit(fit_dir)
+   at_cascade.csv.predict(fit_dir)
+   #
+   # predict_table
+   file_name = f'{fit_dir}/sam_predict.csv'
+   predict_table = at_cascade.csv.read_table(file_name)
+   #
+   # option_predict_table
+   file_name = f'{fit_dir}/option_predict.csv'
+   option_predict_table = at_cascade.csv.read_table(file_name)
+   number_sample_predict = option_predict_table['name' == 'number_sample_predict']['value']
+   for row in option_predict_table:
+      if row['name'] == 'number_sample_predict':
+         number_sample_predict = int( row['value'] )
+   #
+   # check
+   for row in predict_table :
+      sample_index = int( row['sample_index'] )
+      assert sample_index < number_sample_predict
+#
+if __name__ == '__main__' :
+   main()
+   print('csv_fit.py: OK')
+# END_PYTHON


### PR DESCRIPTION
# Changes

Add a new `number_sample_predict` option to option_predict.csv which specifies the number of samples used by the `csv.predict` command. If not specified, `number_sample` from option_fit.csv is used to preserve backwards compatibility.

Add documentation for the new `number_sample_predict` option in the XRST block at the beginning of at_cascade/csv/predict.py.

# Tests

Add a new test:

```txt
/test
└─ /csv
   └─ number_sample_predict.py
```

The test specifies option_predict.csv's `number_sample_predict` greater than option_fit.csv's `number_sample`, runs `csv.fit` and `csv.predict`, and asserts that every row in the sam_predict.csv produced by csv.predict's output table has `sample_index < number_sample_predict`.

The new test passes. An example of its stdout is attached as: 
[20250630T160735.log](https://github.com/user-attachments/files/20988252/20250630T161535.log)

With this new test added, I ran bin/check_all.sh and it passed fully. The stdout of that test run is attached as: 
[20250630T162318.log](https://github.com/user-attachments/files/20988289/20250630T162318.log)

